### PR TITLE
DateTimeTimeZones extension methods implementation

### DIFF
--- a/src/Microsoft.Graph/Microsoft.Graph.Beta.csproj
+++ b/src/Microsoft.Graph/Microsoft.Graph.Beta.csproj
@@ -1,10 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Microsoft Graph beta client library allows you to target the Microsoft Graph /beta endpoint. You can call Office 365, Azure AD and other Microsoft services through a single unified developer experience.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <AssemblyTitle>Microsoft Graph Beta Client Library</AssemblyTitle>
     <Authors>Microsoft</Authors>
-    <TargetFrameworks>netstandard1.1;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
     <PreserveCompilationContext>false</PreserveCompilationContext>
     <AssemblyName>Microsoft.Graph.Beta</AssemblyName>
     <PackageId>Microsoft.Graph.Beta</PackageId>
@@ -13,7 +13,7 @@
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <RepositoryUrl>https://github.com/microsoftgraph/msgraph-beta-sdk-dotnet</RepositoryUrl>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.1' ">1.6.0</NetStandardImplicitPackageVersion>
+    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">1.6.0</NetStandardImplicitPackageVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <SignAssembly>false</SignAssembly>
     <DelaySign>false</DelaySign>

--- a/src/Microsoft.Graph/Models/Extensions/DateTimeZoneExtensions.cs
+++ b/src/Microsoft.Graph/Models/Extensions/DateTimeZoneExtensions.cs
@@ -1,0 +1,158 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+using System;
+using System.Globalization;
+
+namespace Microsoft.Graph.Extensions
+{
+    /// <summary>
+    /// Implements DateTimeTimeZone Extensions
+    /// </summary>
+
+    public static class DateTimeTimeZoneExtensions
+    {
+        /// <summary>
+        /// Converts DateTimeTimeZone which is a Complex Type to DateTime
+        /// </summary>
+        /// <param name="dateTimeTimeZone"></param>
+        /// <returns></returns>
+        public static DateTime ToDateTime(this DateTimeTimeZone dateTimeTimeZone)
+        {
+            DateTime dateTime = DateTime.ParseExact(dateTimeTimeZone.DateTime, DateTimeTimeZone.DateTimeFormat, CultureInfo.InvariantCulture);
+
+            // Now we need to determine which DateTimeKind to set based on the time zone specified in the input object.
+            TimeZoneInfo timeZoneInfo = TimeZoneInfo.FindSystemTimeZoneById(dateTimeTimeZone.TimeZone);
+
+            DateTimeKind kind;
+            if (timeZoneInfo.Id == TimeZoneInfo.Utc.Id)
+            {
+                kind = DateTimeKind.Utc;
+            }
+            else if (timeZoneInfo.Id == TimeZoneInfo.Local.Id)
+            {
+                kind = DateTimeKind.Local;
+            }
+            else
+            {
+                kind = DateTimeKind.Unspecified;
+            }
+
+            return DateTime.SpecifyKind(dateTime, kind);
+        }
+
+        /// <summary>
+        /// Converts DateTimeTimeZone which is a Complex Type to DateTimeOffset
+        /// </summary>
+        /// <param name="dateTimeTimeZone"></param>
+        /// <returns></returns>
+        public static DateTimeOffset ToDateTimeOffset(this DateTimeTimeZone dateTimeTimeZone)
+        {
+            // The resulting DateTimeOffset will have the correct offset for the time zone specified in the input object.
+
+            DateTime dateTime = DateTime.ParseExact(dateTimeTimeZone.DateTime, DateTimeTimeZone.DateTimeFormat, CultureInfo.InvariantCulture);
+            TimeZoneInfo timeZoneInfo = TimeZoneInfo.FindSystemTimeZoneById(dateTimeTimeZone.TimeZone);
+            return dateTime.ToDateTimeOffset(timeZoneInfo);
+        }
+
+        internal static DateTimeOffset ToDateTimeOffset(this DateTime dateTime, TimeZoneInfo timeZoneInfo)
+        {
+            TimeSpan offset;
+            if (timeZoneInfo.IsAmbiguousTime(dateTime))
+            {
+                // Ambiguous times happen when during backward transitions, such as the end of daylight saving time.
+                // Since we were just told this time is ambiguous, there will always be exactly two offsets in the following array:
+                TimeSpan[] offsets = timeZoneInfo.GetAmbiguousTimeOffsets(dateTime);
+
+                // A reasonable common practice is to pick the first occurrence, which is always the largest offset in the array.
+                // Ex: 2019-11-03T01:30:00 in the Pacific time zone occurs twice.  First at 1:30 PDT (-07:00), then an hour later
+                //     at 1:30 PST (-08:00).  We choose PDT (-07:00) because it comes first sequentially.
+                offset = TimeSpan.FromMinutes(Math.Max(offsets[0].TotalMinutes, offsets[1].TotalMinutes));
+            }
+            else if (timeZoneInfo.IsInvalidTime(dateTime))
+            {
+                // Invalid times happen during the gap created by a forward transition, such as the start of daylight saving time.
+                // While they are not values that actually occur in correct local time, they are sometimes encountered
+                // in scenarios such as a scheduled daily task.  In such cases, a reasonable common practice is to advance
+                // to a valid local time by the amount of the transition gap (usually 1 hour).
+                // Ex: 2019-03-10T02:30:00 does not exist in Pacific time.
+                //     The local time went from 01:59:59 PST (-08:00) directly to 03:00:00 PDT (-07:00).
+                //     We will advance by 1 hour to 03:30:00 which is in PDT (-07:00).
+
+                // The gap is usually 1 hour, but not always - so it must be calculated
+                TimeSpan earlierOffset = timeZoneInfo.GetUtcOffset(dateTime.AddDays(-1));
+                TimeSpan laterOffset = timeZoneInfo.GetUtcOffset(dateTime.AddDays(1));
+                TimeSpan gap = laterOffset - earlierOffset;
+
+                dateTime = dateTime.Add(gap);
+                offset = laterOffset;
+            }
+            else
+            {
+                dateTime = DateTime.SpecifyKind(dateTime, DateTimeKind.Utc);
+                offset = timeZoneInfo.GetUtcOffset(dateTime);
+            }
+
+            return new DateTimeOffset(dateTime, offset);
+        }
+    }
+}
+
+namespace Microsoft.Graph
+{
+    public partial class DateTimeTimeZone
+    {
+        internal const string DateTimeFormat = "yyyy-MM-ddTHH:mm:ss.fffffffK";
+
+        /// <summary>
+        /// Converts a Datetime parameter to its equivalent DateTimeTimeZone Complex Type given its TimeZone
+        /// </summary>
+        /// <param name="dateTime">A single point of time in a combined date and time representation ({date}T{time}; for example, 2017-08-29T04:00:00.0000000).</param>
+        /// <returns></returns>
+        public static DateTimeTimeZone FromDateTime(DateTime dateTime)
+        {
+            DateTimeTimeZone dateTimeTimeZone = new DateTimeTimeZone
+            {
+                DateTime = dateTime.ToString(DateTimeFormat, CultureInfo.InvariantCulture),
+                TimeZone = ""
+            };
+
+            return dateTimeTimeZone;
+        }
+
+        /// <summary>
+        /// Converts a Datetime parameter to its equivalent DateTimeTimeZone Complex Type given its TimeZone
+        /// </summary>
+        /// <param name="dateTime">A single point of time in a combined date and time representation ({date}T{time}; for example, 2017-08-29T04:00:00.0000000).</param>
+        /// <param name="timeZone">The expected values for timeZone are specified here: https://docs.microsoft.com/en-us/graph/api/resources/datetimetimezone?view=graph-rest-1.0 </param>
+        /// <returns></returns>
+        public static DateTimeTimeZone FromDateTime(DateTime dateTime, string timeZone)
+        {
+            DateTimeTimeZone dateTimeTimeZone = new DateTimeTimeZone
+            {
+                DateTime = dateTime.ToString(DateTimeFormat, CultureInfo.InvariantCulture),
+                TimeZone = timeZone
+            };
+
+            return dateTimeTimeZone;
+        }
+
+        /// <summary>
+        /// Converts a DatetimeOffset parameter to its equivalent DateTimeTimeZone Complex Type given its TimeZone
+        /// </summary>
+        /// <param name="dateTimeOffset">Represents a point in time, typically expressed as a date and time of day, relative to Coordinated Universal Time (UTC).</param>
+        /// <param name="timeZone">The expected values for timeZone are specified here: https://docs.microsoft.com/en-us/graph/api/resources/datetimetimezone?view=graph-rest-1.0 </param>
+        /// <returns></returns>
+        public static DateTimeTimeZone FromDateTimeOffset(DateTimeOffset dateTimeOffset, string timeZone)
+        {
+            DateTimeTimeZone dateTimeTimeZone = new DateTimeTimeZone
+            {
+                DateTime = dateTimeOffset.ToString(DateTimeFormat, CultureInfo.InvariantCulture),
+                TimeZone = timeZone
+            };
+
+            return dateTimeTimeZone;
+        }
+    }
+}

--- a/tests/Microsoft.Graph.DotnetCore.Test/Models/Extensions/DateTimeZoneExtensionsTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Test/Models/Extensions/DateTimeZoneExtensionsTests.cs
@@ -1,0 +1,115 @@
+﻿using Microsoft.Graph.Extensions;
+using System;
+using Xunit;
+using System.Globalization;
+using System.Collections.Generic;
+
+namespace Microsoft.Graph.DotnetCore.Test.Extensions
+{
+    public class DateTimeZoneExtensionsTests
+    {
+        internal const string DateTimeFormat = "yyyy-MM-ddTHH:mm:ss.fffffffK";
+
+        [Fact]
+        public void ToDateTime_Should_Convert_DateTimeTimeZone_To_DateTime()
+        {
+            DateTimeTimeZone dateTimeTimeZone = new DateTimeTimeZone
+            {
+                TimeZone = "UTC",
+                DateTime = "2019-01-25T06:37:39.8058788Z"
+            };
+
+            var actualDateTime = dateTimeTimeZone.ToDateTime();
+            var expectedDateTime = DateTime.ParseExact(dateTimeTimeZone.DateTime, DateTimeFormat, CultureInfo.InvariantCulture);
+                                 
+            Assert.Equal(expectedDateTime, actualDateTime);
+        }
+
+        [Fact]
+        public void ToDateTimeOffset_Should_Convert_DateTimeTimeZone_To_DateTimeOffset()
+        {
+            DateTimeTimeZone dateTimeTimeZone = new DateTimeTimeZone
+            {
+                TimeZone = "UTC",
+                DateTime = "2019-01-25T06:37:39.8058788Z"
+            };
+
+            DateTime dateTime = DateTime.ParseExact(dateTimeTimeZone.DateTime, DateTimeFormat, CultureInfo.InvariantCulture);
+            TimeZoneInfo timeZoneInfo = TimeZoneInfo.FindSystemTimeZoneById(dateTimeTimeZone.TimeZone);
+            TimeSpan offset = timeZoneInfo.GetUtcOffset(dateTime);
+            dateTime = DateTime.SpecifyKind(dateTime, DateTimeKind.Utc);
+
+            var expectedDateTimeOffset = new DateTimeOffset(dateTime, offset);
+            var actualDateTimeOffset = dateTimeTimeZone.ToDateTimeOffset();
+
+            Assert.Equal(expectedDateTimeOffset, actualDateTimeOffset);
+        }
+
+        [Fact]
+        public void FromDateTime_Should_Convert_DateTime_To_DateTimeTimeZone()
+        {
+            DateTimeStyles dateTimeStyles = DateTimeStyles.RoundtripKind;
+            var dateTime = DateTime.ParseExact("2019-01-25T06:37:39.8058788Z", DateTimeFormat, CultureInfo.InvariantCulture, dateTimeStyles);
+            var expectedDateTime = dateTime.ToString(DateTimeFormat, CultureInfo.InvariantCulture);
+
+            DateTimeTimeZone expectedDateTimeTimeZone = new DateTimeTimeZone
+            {
+                TimeZone = "UTC",
+                DateTime = expectedDateTime
+            };
+
+            var actualDateTimeTimeZone = DateTimeTimeZone.FromDateTime(dateTime, "UTC");
+
+            Assert.Equal(expectedDateTimeTimeZone.DateTime, actualDateTimeTimeZone.DateTime);
+            Assert.Equal(expectedDateTimeTimeZone.TimeZone, actualDateTimeTimeZone.TimeZone);
+        }
+
+        [Fact]
+        public void FromDateTimeOffset_Should_Convert_DateTimeOffset_To_DateTimeTimeZone()
+        {
+            List<DateTimeTimeZone> dateTimeTimeZoneList = new List<DateTimeTimeZone>();
+            DateTimeTimeZone dateTimeTimeZoneTestOne = new DateTimeTimeZone
+            {
+                TimeZone = "Eastern Standard Time",
+                DateTime = "2019-06-03T14:00:00.0000000"
+            };
+            dateTimeTimeZoneList.Add(dateTimeTimeZoneTestOne);
+
+            DateTimeTimeZone dateTimeTimeZoneTestTwo = new DateTimeTimeZone
+            {
+                TimeZone = "UTC",
+                DateTime = "2019-01-25T06:37:39.8058788Z"
+            };
+            dateTimeTimeZoneList.Add(dateTimeTimeZoneTestTwo);
+
+            DateTimeTimeZone dateTimeTimeZoneTestThree = new DateTimeTimeZone
+            {
+                TimeZone = "Mauritius Standard Time",
+                DateTime = "2019-06-03T22:00:00.0000000"
+            };
+            dateTimeTimeZoneList.Add(dateTimeTimeZoneTestThree);
+            
+            foreach (var dateTimeTimeZone in dateTimeTimeZoneList)
+            {
+                DateTime dateTime = GetDateTimeFromDateTimeTimeZone(dateTimeTimeZone);
+                TimeZoneInfo timeZoneInfo = TimeZoneInfo.FindSystemTimeZoneById(dateTimeTimeZone.TimeZone);
+
+                TimeSpan offset = timeZoneInfo.GetUtcOffset(dateTime);
+                dateTime = DateTime.SpecifyKind(dateTime, DateTimeKind.Unspecified);
+
+                var expectedDateTimeOffset = new DateTimeOffset(dateTime, offset);
+                expectedDateTimeOffset = TimeZoneInfo.ConvertTime(expectedDateTimeOffset, timeZoneInfo);
+                var actualDateTimeTimeZone = DateTimeTimeZone.FromDateTimeOffset(expectedDateTimeOffset, dateTimeTimeZone.TimeZone);
+
+                Assert.Equal(expectedDateTimeOffset.ToString(DateTimeFormat, CultureInfo.InvariantCulture), actualDateTimeTimeZone.DateTime);
+                Assert.Equal(timeZoneInfo.Id, actualDateTimeTimeZone.TimeZone);
+            }
+        }
+
+        private DateTime GetDateTimeFromDateTimeTimeZone(DateTimeTimeZone dateTimeTimeZone)
+        {
+            DateTime dateTime = DateTime.ParseExact(dateTimeTimeZone.DateTime, DateTimeFormat, CultureInfo.InvariantCulture);
+            return dateTime;
+        }
+    }
+}


### PR DESCRIPTION
### Changes proposed in this pull request
This PR implements the Core enhancement as requested here [https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/366](https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/366)

It has two extension methods; 
-  **ToDateTime**
 - **ToDateTimeOffset**

And two static methods;
 - **FromDateTime**
 - **FromDateTimeOffset**

Test methods were also added under **Microsoft.Graph.DotnetCore.Test > Models > Extensions**

Please note to accommodate some of the .Net built-in date functions and properties I updated the framework from .NETStandard 1.1 to .NETStandard 1.3 
