### PR TITLE
Descriptive build name and no notify manual build

### DIFF
--- a/pipelines/validatePR.yml
+++ b/pipelines/validatePR.yml
@@ -5,20 +5,20 @@ name: $(BuildDefinitionName)_$(SourceBranchName)_$(Date:yyyyMMdd)$(Rev:.r)
 pr:
   branches:
     include:
-    - master
+      master
   paths:
     exclude:
-        - .github/*
-        - .vs/*
-        - pipelines/*
-        - scripts/*
-        - tests/*
-        - .gitignore
-        - CONTRIBUTING.md
-        - LICENSE.txt
-        - Microsoft.Graph.Beta.sln
-        - README.md
-        - THIRD PARTY NOTICES
+      .github/*
+      .vs/*
+      pipelines/*
+      scripts/*
+      tests/*
+      .gitignore
+      CONTRIBUTING.md
+      LICENSE.txt
+      Microsoft.Graph.Beta.sln
+      README.md
+      THIRD PARTY NOTICES
 
 pool:
   name: Hosted VS2017

--- a/pipelines/validatePR.yml
+++ b/pipelines/validatePR.yml
@@ -5,20 +5,20 @@ name: $(BuildDefinitionName)_$(SourceBranchName)_$(Date:yyyyMMdd)$(Rev:.r)
 pr:
   branches:
     include:
-      master
+      - master
   paths:
     exclude:
-      .github/*
-      .vs/*
-      pipelines/*
-      scripts/*
-      tests/*
-      .gitignore
-      CONTRIBUTING.md
-      LICENSE.txt
-      Microsoft.Graph.Beta.sln
-      README.md
-      THIRD PARTY NOTICES
+      - .github/*
+      - .vs/*
+      - pipelines/*
+      - scripts/*
+      - tests/*
+      - .gitignore
+      - CONTRIBUTING.md
+      - LICENSE.txt
+      - Microsoft.Graph.Beta.sln
+      - README.md
+      - THIRD PARTY NOTICES
 
 pool:
   name: Hosted VS2017

--- a/pipelines/validatePR.yml
+++ b/pipelines/validatePR.yml
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
+name: $(BuildDefinitionName)_$(SourceBranchName)_$(Date:yyyyMMdd)$(Rev:.r)
 pr:
   branches:
     include:
@@ -56,5 +57,5 @@ steps:
     serviceEndpointName: 'microsoftgraph pipeline status'
     title: '$(Build.DefinitionName) failure notification'
     text: 'This pipeline has failed. View the build details for further information. This is a blocking failure. '
-  condition: failed()
+  condition: and(failed(), ne(variables['Build.Reason'], 'Manual'))
   enabled: true


### PR DESCRIPTION
Update validatePR.yml with:
* descriptive build name so it is easy to discern what pipeline a specific build is from.
* don't send fail notifications for manual builds.