### PR TITLE
Update M.G.C minimum package reference version

### DIFF
--- a/src/Microsoft.Graph/Microsoft.Graph.Beta.csproj
+++ b/src/Microsoft.Graph/Microsoft.Graph.Beta.csproj
@@ -38,7 +38,7 @@
     <None Include=".\..\..\LICENSE.txt" Pack="true" PackagePath="" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Graph.Core" Version="[1.19.0-preview.5,2)" />
+    <PackageReference Include="Microsoft.Graph.Core" Version="[1.19.0,2)" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <Reference Include="System" />


### PR DESCRIPTION
Customers should not use the preview any longer. We will delist the previews.