### PR TITLE
Add PR action

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,24 @@
+name: "Create pull request"
+
+on:
+  push:
+    branches:
+    - "beta/pipelinebuild/*"  # Support wildcard matching
+
+jobs:
+  pull-request:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: pull-request
+      uses: repo-sync/pull-request@v2
+      with:
+        source_branch: ""                     # If blank, default: triggered branch
+        destination_branch: "master"          # If blank, default: master
+        pr_title: "Generated models and request builders using Typewriter"
+        pr_body: ":crown: *An automated PR*"  # Full markdown support, requires pr_title to be set
+        pr_reviewer: "peombwa"             # Comma-separated list (no spaces)
+        pr_assignee: "ddyett"             # Comma-separated list (no spaces)
+        pr_label: "generated"                   # Comma-separated list (no spaces)
+        # pr_milestone: "Milestone 1"           # Milestone name
+        github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This will automatically open a PR when we have a branch spec that matches `"beta/pipelinebuild/*"`. We can remove the need to use GitHub/hub with PAT to create a PR.

This action is https://github.com/repo-sync/pull-request/tree/v2.0.0