### PR TITLE
Fix SerializeAndDeserializeKnownEnumValue test

### DIFF
--- a/tests/Microsoft.Graph.DotnetCore.Test/Models/ModelSerializationTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Test/Models/ModelSerializationTests.cs
@@ -139,7 +139,7 @@ namespace Microsoft.Graph.DotnetCore.Test.Models
             };
 
             var expectedSerializedStream = string.Format(
-                "{{\"contentType\":\"{1}\",\"content\":\"{0}\",\"@odata.type\":\"microsoft.graph.itemBody\"}}",
+                "{{\"content\":\"{0}\",\"contentType\":\"{1}\",\"@odata.type\":\"microsoft.graph.itemBody\"}}",
                 itemBody.Content,
                 "text");
 


### PR DESCRIPTION
This test is brittle as it depends on serialization order. A reorder in
the CSDL will break this test. That is what is precipitating this change.

This update is required for generation to successfully complete.

related: https://github.com/microsoftgraph/msgraph-sdk-dotnet/commit/8bd80488c725ed27bf1b45c4d313fc39c278d426