### PR TITLE
Add type summary to Beta generation process

### DIFF
--- a/pipelines/generateServiceLibrary.yml
+++ b/pipelines/generateServiceLibrary.yml
@@ -12,7 +12,7 @@ resources:
     type: github
     endpoint: microsoftgraph
     name: microsoftgraph/msgraph-beta-sdk-dotnet
-    ref: zengin/typeSummary # checkout the master branch
+    ref: master # checkout the master branch
   - repository: msgraph-metadata
     type: github
     endpoint: microsoftgraph

--- a/pipelines/generateServiceLibrary.yml
+++ b/pipelines/generateServiceLibrary.yml
@@ -52,7 +52,7 @@ steps:
       Write-Host "Path to repo model directory: $repoModelsDir"
       Write-Host "##vso[task.setvariable variable=repoModelsDir]$repoModelsDir"
 
-      $typeSummaryFilePath = "$env:Build_SourcesDirectory\msgraph-sdk-dotnet\typeSummary.txt"
+      $typeSummaryFilePath = "$env:Build_SourcesDirectory\msgraph-beta-sdk-dotnet\typeSummary.txt"
       Write-Host "Path to type summary: $typeSummaryFilePath"
       Write-Host "##vso[task.setvariable variable=typeSummaryFilePath]$typeSummaryFilePath"
 

--- a/pipelines/generateServiceLibrary.yml
+++ b/pipelines/generateServiceLibrary.yml
@@ -47,11 +47,15 @@ steps:
   inputs:
     targetType: inline
     script: |
-      
+
       $repoModelsDir = "$env:Build_SourcesDirectory\msgraph-beta-sdk-dotnet\src\Microsoft.Graph\Generated\"
       Write-Host "Path to repo model directory: $repoModelsDir"
       Write-Host "##vso[task.setvariable variable=repoModelsDir]$repoModelsDir"
-      
+
+      $typeSummaryFilePath = "$env:Build_SourcesDirectory\msgraph-sdk-dotnet\typeSummary.txt"
+      Write-Host "Path to type summary: $typeSummaryFilePath"
+      Write-Host "##vso[task.setvariable variable=typeSummaryFilePath]$typeSummaryFilePath"
+
       $outputPath = Join-Path $env:Build_SourcesDirectory "output"
       Write-Host "Path to typewriter.exe output $outputPath"
       Write-Host "##vso[task.setvariable variable=outputPath]$outputPath"
@@ -134,6 +138,26 @@ steps:
   inputs:
     diagnosticsEnabled: True
 
+- task: PowerShell@2 # Setup environment variables and make them available to all tasks. See [1] for more info.
+  displayName: 'Get DLL path'
+  inputs:
+    targetType: inline
+    script: |
+      $allGeneratedDlls = Get-ChildItem $dir -Include Microsoft.Graph.Beta.dll -Recurse
+      $dotNetFrameworkDll = $allGeneratedDlls | Where-Object { !$_.FullName.Contains("obj") -and !$_.FullName.Contains("netstandard") }
+      $dllPath = $dotNetFrameworkDll.FullName
+      Write-Host "Path to Microsoft.Graph.Beta.dll: $dllPath"
+      Write-Host "##vso[task.setvariable variable=dllPath]$dllPath"
+
+- task: PowerShell@2
+  displayName: 'Generate type summary'
+  inputs:
+    targetType: filePath
+    filePath: '$(Build.SourcesDirectory)/msgraph-beta-sdk-dotnet/scripts/generateTypeSummary.ps1'
+    arguments: '-dllPath $(dllPath) -outputPath $(typeSummaryFilePath)'
+    workingDirectory: '$(Build.SourcesDirectory)' # Set the root for a multi-repo pipeline. /s
+  enabled: true
+
 - task: PowerShell@2
   displayName: 'Git: stage and commit generated files'
   inputs:
@@ -143,7 +167,16 @@ steps:
       Write-Host "About to add files....." -ForegroundColor Green
 
       git add . | Write-Host
-      git commit -m "Update generated files with build $env:Build_BuildId" | Write-Host
+
+      if ($env:Build_Reason -eq 'Manual') # Skip CI if manually running this pipeline.
+      {
+        git commit -m "Update generated files with build $env:Build_BuildId [skip ci]" | Write-Host
+      }
+      else
+      {
+        git commit -m "Update generated files with build $env:Build_BuildId" | Write-Host
+      }
+
       Write-Host "Added and commited generated files." -ForegroundColor Green
 
 - task: PowerShell@2

--- a/pipelines/generateServiceLibrary.yml
+++ b/pipelines/generateServiceLibrary.yml
@@ -12,7 +12,7 @@ resources:
     type: github
     endpoint: microsoftgraph
     name: microsoftgraph/msgraph-beta-sdk-dotnet
-    ref: master # checkout the master branch
+    ref: zengin/typeSummary # checkout the master branch
   - repository: msgraph-metadata
     type: github
     endpoint: microsoftgraph

--- a/scripts/generateTypeSummary.ps1
+++ b/scripts/generateTypeSummary.ps1
@@ -1,0 +1,106 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+<#
+.SYNOPSIS
+    Creates a type summary from DLL
+
+.DESCRIPTION
+    Takes a Microsoft.Graph DLL and prints types as a flat text file
+    - Selects types that fall under Microsoft.Graph namespace
+    - Drops version information from full generic type names
+    - Types are sorted as enums, interfaces and classes
+      - Each type of types are sorted among themselves by name
+    - Properties and methods are also sorted by their name
+      - For deterministic results, overloaded methods are also sorted by their argument list
+
+.PARAMETER dllPath
+    Full path to Microsoft.Graph.dll
+
+.PARAMETER outputPath
+    Full Path to type summary file
+
+.EXAMPLE
+    PS C:\> .\generateTypeSummary.ps1 -dllPath C:\test\Microsoft.Graph.dll -outputPath C:\test\typeSummary.txt
+#>
+
+Param(
+    [string]$dllPath,
+    [string]$outputPath
+)
+
+$twoSpaces = "  "
+$fourSpaces = "    "
+
+$assembly = [System.Reflection.Assembly]::LoadFrom($dllPath)
+$types = $assembly.GetTypes() |
+    Where-Object { $_.FullName.StartsWith("Microsoft.Graph") } |
+    Sort-Object { $_.FullName }
+
+function normalize([string]$str)
+{
+    # removes package version information for cleaner diffs
+    # e.g. , Microsoft.Graph, Version=3.12.0.0, Culture=neutral, PublicKeyToken=null
+    return $str -replace ", [\w\.]+, Version=\d+\.\d+\.\d+\.\d+, Culture=neutral, PublicKeyToken=(null|[a-f0-9]+)",""
+}
+
+$writer = [System.IO.File]::CreateText($outputPath)
+
+try
+{
+    # enum types
+    foreach ($type in $types | Where-Object { $_.IsEnum })
+    {
+        $writer.WriteLine("enum " + $type.FullName)
+
+        foreach ($enumName in $type.GetEnumNames())
+        {
+            $writer.WriteLine($twoSpaces + $enumName)
+        }
+    }
+
+    # interface and class types
+    foreach ($type in $types |
+        Where-Object { !$_.FullName.Contains("+") -and ($_.IsClass -or $_.IsInterface) } |
+        Sort-Object { $_.IsInterface,$_.Name })
+    {
+        # type declaration line with optional base type
+        $declaration = "class "
+        if ($type.IsInterface)
+        {
+            $declaration = "interface "
+        }
+
+        $declaration += $type.FullName
+        if ($type.BaseType -and $type.BaseType.FullName -ne "System.Object")
+        {
+            $declaration += " : " + (normalize $type.BaseType.FullName)
+        }
+
+        $writer.WriteLine($declaration)
+
+        # properties
+        foreach ($property in $type.GetProperties() | Where-Object { $_.DeclaringType -eq $type } | Sort-Object { $_.Name })
+        {
+            $writer.WriteLine($twoSpaces + "property " + $property.Name + $getterSetter + " : " + (normalize $property.PropertyType.FullName))
+        }
+
+        # methods
+        foreach ($method in $type.GetMethods() |
+            Where-Object { $_.DeclaringType -eq $type -and !$_.Name.StartsWith("set_") -and !$_.Name.StartsWith("get_")} |
+            Sort-Object { $_.Name,($_.GetParameters().Name -join " ") }) # get a deterministic order among methods
+        {
+            $writer.WriteLine($twoSpaces + "method " + $method.Name)
+            $writer.WriteLine($fourSpaces + "return type " + (normalize $method.ReturnType.FullName))
+
+            foreach($param in $method.GetParameters())
+            {
+                $writer.WriteLine($fourSpaces + "param " + $param.Name + " : " + (normalize $param.ParameterType.FullName))
+            }
+        }
+    }
+}
+finally
+{
+    $writer.Close()
+}

--- a/src/Microsoft.Graph/Microsoft.Graph.Beta.csproj
+++ b/src/Microsoft.Graph/Microsoft.Graph.Beta.csproj
@@ -22,7 +22,7 @@
     <PackageReleaseNotes>
     </PackageReleaseNotes>
     <!-- edit this value to change the current major.minor.patch version -->
-    <VersionPrefix>0.27.0</VersionPrefix>
+    <VersionPrefix>0.26.0</VersionPrefix>
     <!-- adds a version suffix if the Prerelease environment variable is set. BUILD_BUILDID is an
     environment variable set by Azure pipelines from the build. We can use the buildid to correlate
     which commit was used to generate the preview build. -->

--- a/src/Microsoft.Graph/Microsoft.Graph.Beta.csproj
+++ b/src/Microsoft.Graph/Microsoft.Graph.Beta.csproj
@@ -22,7 +22,7 @@
     <PackageReleaseNotes>
     </PackageReleaseNotes>
     <!-- edit this value to change the current major.minor.patch version -->
-    <VersionPrefix>0.26.0</VersionPrefix>
+    <VersionPrefix>0.27.0</VersionPrefix>
     <!-- adds a version suffix if the Prerelease environment variable is set. BUILD_BUILDID is an
     environment variable set by Azure pipelines from the build. We can use the buildid to correlate
     which commit was used to generate the preview build. -->


### PR DESCRIPTION
- Adds generateTypeSummary script from msgraph-sdk-dotnet repo
- Adds pipeline steps to generate type summary
- Adds the initial `typeSummary.txt` file to represent current type list
- Fixes [skip ci] behavior for Github Action to skip generating PRs for manual runs

Perf: adds 3.5 minutes to Beta generation process, we can consider making this a separate stage if it is desired to be skipped in manual runs.