### PR TITLE
Fix methods that return primitives

### DIFF
--- a/src/Microsoft.Graph/Generated/requests/AndroidForWorkSettingsRequestSignupUrlRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/AndroidForWorkSettingsRequestSignupUrlRequest.cs
@@ -51,11 +51,12 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<string> PostAsync(
+        public async System.Threading.Tasks.Task<string> PostAsync(
             CancellationToken cancellationToken)
         {
             this.Method = "POST";
-            return this.SendAsync<string>(this.RequestBody, cancellationToken);
+            var response = await this.SendAsync<ODataMethodStringResponse>(this.RequestBody, cancellationToken);
+            return response.Value;
         }
 
 

--- a/src/Microsoft.Graph/Generated/requests/AndroidManagedStoreAccountEnterpriseSettingsCreateGooglePlayWebTokenRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/AndroidManagedStoreAccountEnterpriseSettingsCreateGooglePlayWebTokenRequest.cs
@@ -51,11 +51,12 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<string> PostAsync(
+        public async System.Threading.Tasks.Task<string> PostAsync(
             CancellationToken cancellationToken)
         {
             this.Method = "POST";
-            return this.SendAsync<string>(this.RequestBody, cancellationToken);
+            var response = await this.SendAsync<ODataMethodStringResponse>(this.RequestBody, cancellationToken);
+            return response.Value;
         }
 
 

--- a/src/Microsoft.Graph/Generated/requests/AndroidManagedStoreAccountEnterpriseSettingsRequestSignupUrlRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/AndroidManagedStoreAccountEnterpriseSettingsRequestSignupUrlRequest.cs
@@ -51,11 +51,12 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<string> PostAsync(
+        public async System.Threading.Tasks.Task<string> PostAsync(
             CancellationToken cancellationToken)
         {
             this.Method = "POST";
-            return this.SendAsync<string>(this.RequestBody, cancellationToken);
+            var response = await this.SendAsync<ODataMethodStringResponse>(this.RequestBody, cancellationToken);
+            return response.Value;
         }
 
 

--- a/src/Microsoft.Graph/Generated/requests/ApplePushNotificationCertificateDownloadApplePushNotificationCertificateSigningRequestRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ApplePushNotificationCertificateDownloadApplePushNotificationCertificateSigningRequestRequest.cs
@@ -44,11 +44,12 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<string> GetAsync(
+        public async System.Threading.Tasks.Task<string> GetAsync(
             CancellationToken cancellationToken)
         {
             this.Method = "GET";
-            return this.SendAsync<string>(null, cancellationToken);
+            var response = await this.SendAsync<ODataMethodStringResponse>(null, cancellationToken);
+            return response.Value;
         }
 
 

--- a/src/Microsoft.Graph/Generated/requests/ApplePushNotificationCertificateGenerateApplePushNotificationCertificateSigningRequestRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ApplePushNotificationCertificateGenerateApplePushNotificationCertificateSigningRequestRequest.cs
@@ -44,11 +44,12 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<string> PostAsync(
+        public async System.Threading.Tasks.Task<string> PostAsync(
             CancellationToken cancellationToken)
         {
             this.Method = "POST";
-            return this.SendAsync<string>(null, cancellationToken);
+            var response = await this.SendAsync<ODataMethodStringResponse>(null, cancellationToken);
+            return response.Value;
         }
 
 

--- a/src/Microsoft.Graph/Generated/requests/DepOnboardingSettingGenerateEncryptionPublicKeyRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/DepOnboardingSettingGenerateEncryptionPublicKeyRequest.cs
@@ -44,11 +44,12 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<string> PostAsync(
+        public async System.Threading.Tasks.Task<string> PostAsync(
             CancellationToken cancellationToken)
         {
             this.Method = "POST";
-            return this.SendAsync<string>(null, cancellationToken);
+            var response = await this.SendAsync<ODataMethodStringResponse>(null, cancellationToken);
+            return response.Value;
         }
 
 

--- a/src/Microsoft.Graph/Generated/requests/DepOnboardingSettingGetEncryptionPublicKeyRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/DepOnboardingSettingGetEncryptionPublicKeyRequest.cs
@@ -44,11 +44,12 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<string> GetAsync(
+        public async System.Threading.Tasks.Task<string> GetAsync(
             CancellationToken cancellationToken)
         {
             this.Method = "GET";
-            return this.SendAsync<string>(null, cancellationToken);
+            var response = await this.SendAsync<ODataMethodStringResponse>(null, cancellationToken);
+            return response.Value;
         }
 
 

--- a/src/Microsoft.Graph/Generated/requests/DepOnboardingSettingGetExpiringVppTokenCountRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/DepOnboardingSettingGetExpiringVppTokenCountRequest.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Issues the GET request.
         /// </summary>
-        public System.Threading.Tasks.Task<Int32> GetAsync()
+        public System.Threading.Tasks.Task<Int32?> GetAsync()
         {
             return this.GetAsync(CancellationToken.None);
         }
@@ -44,7 +44,7 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<Int32> GetAsync(
+        public async System.Threading.Tasks.Task<Int32?> GetAsync(
             CancellationToken cancellationToken)
         {
             this.Method = "GET";

--- a/src/Microsoft.Graph/Generated/requests/DepOnboardingSettingGetExpiringVppTokenCountRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/DepOnboardingSettingGetExpiringVppTokenCountRequest.cs
@@ -44,11 +44,12 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Int32> GetAsync(
+        public async System.Threading.Tasks.Task<Int32> GetAsync(
             CancellationToken cancellationToken)
         {
             this.Method = "GET";
-            return this.SendAsync<Int32>(null, cancellationToken);
+            var response = await this.SendAsync<ODataMethodIntResponse>(null, cancellationToken);
+            return response.Value;
         }
 
 

--- a/src/Microsoft.Graph/Generated/requests/DeviceHealthScriptGetGlobalScriptHighestAvailableVersionRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/DeviceHealthScriptGetGlobalScriptHighestAvailableVersionRequest.cs
@@ -44,11 +44,12 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<string> PostAsync(
+        public async System.Threading.Tasks.Task<string> PostAsync(
             CancellationToken cancellationToken)
         {
             this.Method = "POST";
-            return this.SendAsync<string>(null, cancellationToken);
+            var response = await this.SendAsync<ODataMethodStringResponse>(null, cancellationToken);
+            return response.Value;
         }
 
 

--- a/src/Microsoft.Graph/Generated/requests/DeviceHealthScriptUpdateGlobalScriptRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/DeviceHealthScriptUpdateGlobalScriptRequest.cs
@@ -51,11 +51,12 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<string> PostAsync(
+        public async System.Threading.Tasks.Task<string> PostAsync(
             CancellationToken cancellationToken)
         {
             this.Method = "POST";
-            return this.SendAsync<string>(this.RequestBody, cancellationToken);
+            var response = await this.SendAsync<ODataMethodStringResponse>(this.RequestBody, cancellationToken);
+            return response.Value;
         }
 
 

--- a/src/Microsoft.Graph/Generated/requests/DeviceLogCollectionResponseCreateDownloadUrlRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/DeviceLogCollectionResponseCreateDownloadUrlRequest.cs
@@ -44,11 +44,12 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<string> PostAsync(
+        public async System.Threading.Tasks.Task<string> PostAsync(
             CancellationToken cancellationToken)
         {
             this.Method = "POST";
-            return this.SendAsync<string>(null, cancellationToken);
+            var response = await this.SendAsync<ODataMethodStringResponse>(null, cancellationToken);
+            return response.Value;
         }
 
 

--- a/src/Microsoft.Graph/Generated/requests/DeviceManagementScopedForResourceRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/DeviceManagementScopedForResourceRequest.cs
@@ -44,11 +44,12 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<bool> GetAsync(
+        public async System.Threading.Tasks.Task<bool> GetAsync(
             CancellationToken cancellationToken)
         {
             this.Method = "GET";
-            return this.SendAsync<bool>(null, cancellationToken);
+            var response = await this.SendAsync<ODataMethodBooleanResponse>(null, cancellationToken);
+            return response.Value;
         }
 
 

--- a/src/Microsoft.Graph/Generated/requests/DeviceManagementScopedForResourceRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/DeviceManagementScopedForResourceRequest.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Issues the GET request.
         /// </summary>
-        public System.Threading.Tasks.Task<bool> GetAsync()
+        public System.Threading.Tasks.Task<bool?> GetAsync()
         {
             return this.GetAsync(CancellationToken.None);
         }
@@ -44,7 +44,7 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<bool> GetAsync(
+        public async System.Threading.Tasks.Task<bool?> GetAsync(
             CancellationToken cancellationToken)
         {
             this.Method = "GET";

--- a/src/Microsoft.Graph/Generated/requests/DeviceManagementVerifyWindowsEnrollmentAutoDiscoveryRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/DeviceManagementVerifyWindowsEnrollmentAutoDiscoveryRequest.cs
@@ -44,11 +44,12 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<bool> GetAsync(
+        public async System.Threading.Tasks.Task<bool> GetAsync(
             CancellationToken cancellationToken)
         {
             this.Method = "GET";
-            return this.SendAsync<bool>(null, cancellationToken);
+            var response = await this.SendAsync<ODataMethodBooleanResponse>(null, cancellationToken);
+            return response.Value;
         }
 
 

--- a/src/Microsoft.Graph/Generated/requests/DeviceManagementVerifyWindowsEnrollmentAutoDiscoveryRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/DeviceManagementVerifyWindowsEnrollmentAutoDiscoveryRequest.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Issues the GET request.
         /// </summary>
-        public System.Threading.Tasks.Task<bool> GetAsync()
+        public System.Threading.Tasks.Task<bool?> GetAsync()
         {
             return this.GetAsync(CancellationToken.None);
         }
@@ -44,7 +44,7 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<bool> GetAsync(
+        public async System.Threading.Tasks.Task<bool?> GetAsync(
             CancellationToken cancellationToken)
         {
             this.Method = "GET";

--- a/src/Microsoft.Graph/Generated/requests/EducationAssignmentGetResourcesFolderUrlRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/EducationAssignmentGetResourcesFolderUrlRequest.cs
@@ -44,11 +44,12 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<string> GetAsync(
+        public async System.Threading.Tasks.Task<string> GetAsync(
             CancellationToken cancellationToken)
         {
             this.Method = "GET";
-            return this.SendAsync<string>(null, cancellationToken);
+            var response = await this.SendAsync<ODataMethodStringResponse>(null, cancellationToken);
+            return response.Value;
         }
 
 

--- a/src/Microsoft.Graph/Generated/requests/EducationSynchronizationProfileUploadUrlRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/EducationSynchronizationProfileUploadUrlRequest.cs
@@ -44,11 +44,12 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<string> GetAsync(
+        public async System.Threading.Tasks.Task<string> GetAsync(
             CancellationToken cancellationToken)
         {
             this.Method = "GET";
-            return this.SendAsync<string>(null, cancellationToken);
+            var response = await this.SendAsync<ODataMethodStringResponse>(null, cancellationToken);
+            return response.Value;
         }
 
 

--- a/src/Microsoft.Graph/Generated/requests/EnrollmentProfileExportMobileConfigRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/EnrollmentProfileExportMobileConfigRequest.cs
@@ -44,11 +44,12 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<string> GetAsync(
+        public async System.Threading.Tasks.Task<string> GetAsync(
             CancellationToken cancellationToken)
         {
             this.Method = "GET";
-            return this.SendAsync<string>(null, cancellationToken);
+            var response = await this.SendAsync<ODataMethodStringResponse>(null, cancellationToken);
+            return response.Value;
         }
 
 

--- a/src/Microsoft.Graph/Generated/requests/GroupLifecyclePolicyAddGroupRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/GroupLifecyclePolicyAddGroupRequest.cs
@@ -51,11 +51,12 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<bool> PostAsync(
+        public async System.Threading.Tasks.Task<bool> PostAsync(
             CancellationToken cancellationToken)
         {
             this.Method = "POST";
-            return this.SendAsync<bool>(this.RequestBody, cancellationToken);
+            var response = await this.SendAsync<ODataMethodBooleanResponse>(this.RequestBody, cancellationToken);
+            return response.Value;
         }
 
 

--- a/src/Microsoft.Graph/Generated/requests/GroupLifecyclePolicyAddGroupRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/GroupLifecyclePolicyAddGroupRequest.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Issues the POST request.
         /// </summary>
-        public System.Threading.Tasks.Task<bool> PostAsync()
+        public System.Threading.Tasks.Task<bool?> PostAsync()
         {
             return this.PostAsync(CancellationToken.None);
         }
@@ -51,7 +51,7 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<bool> PostAsync(
+        public async System.Threading.Tasks.Task<bool?> PostAsync(
             CancellationToken cancellationToken)
         {
             this.Method = "POST";

--- a/src/Microsoft.Graph/Generated/requests/GroupLifecyclePolicyRemoveGroupRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/GroupLifecyclePolicyRemoveGroupRequest.cs
@@ -51,11 +51,12 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<bool> PostAsync(
+        public async System.Threading.Tasks.Task<bool> PostAsync(
             CancellationToken cancellationToken)
         {
             this.Method = "POST";
-            return this.SendAsync<bool>(this.RequestBody, cancellationToken);
+            var response = await this.SendAsync<ODataMethodBooleanResponse>(this.RequestBody, cancellationToken);
+            return response.Value;
         }
 
 

--- a/src/Microsoft.Graph/Generated/requests/GroupLifecyclePolicyRemoveGroupRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/GroupLifecyclePolicyRemoveGroupRequest.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Issues the POST request.
         /// </summary>
-        public System.Threading.Tasks.Task<bool> PostAsync()
+        public System.Threading.Tasks.Task<bool?> PostAsync()
         {
             return this.PostAsync(CancellationToken.None);
         }
@@ -51,7 +51,7 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<bool> PostAsync(
+        public async System.Threading.Tasks.Task<bool?> PostAsync(
             CancellationToken cancellationToken)
         {
             this.Method = "POST";

--- a/src/Microsoft.Graph/Generated/requests/GroupLifecyclePolicyRenewGroupRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/GroupLifecyclePolicyRenewGroupRequest.cs
@@ -51,11 +51,12 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<bool> PostAsync(
+        public async System.Threading.Tasks.Task<bool> PostAsync(
             CancellationToken cancellationToken)
         {
             this.Method = "POST";
-            return this.SendAsync<bool>(this.RequestBody, cancellationToken);
+            var response = await this.SendAsync<ODataMethodBooleanResponse>(this.RequestBody, cancellationToken);
+            return response.Value;
         }
 
 

--- a/src/Microsoft.Graph/Generated/requests/GroupLifecyclePolicyRenewGroupRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/GroupLifecyclePolicyRenewGroupRequest.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Issues the POST request.
         /// </summary>
-        public System.Threading.Tasks.Task<bool> PostAsync()
+        public System.Threading.Tasks.Task<bool?> PostAsync()
         {
             return this.PostAsync(CancellationToken.None);
         }
@@ -51,7 +51,7 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<bool> PostAsync(
+        public async System.Threading.Tasks.Task<bool?> PostAsync(
             CancellationToken cancellationToken)
         {
             this.Method = "POST";

--- a/src/Microsoft.Graph/Generated/requests/GroupPolicyMigrationReportCreateMigrationReportRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/GroupPolicyMigrationReportCreateMigrationReportRequest.cs
@@ -51,11 +51,12 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<string> PostAsync(
+        public async System.Threading.Tasks.Task<string> PostAsync(
             CancellationToken cancellationToken)
         {
             this.Method = "POST";
-            return this.SendAsync<string>(this.RequestBody, cancellationToken);
+            var response = await this.SendAsync<ODataMethodStringResponse>(this.RequestBody, cancellationToken);
+            return response.Value;
         }
 
 

--- a/src/Microsoft.Graph/Generated/requests/IDepOnboardingSettingGetExpiringVppTokenCountRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/IDepOnboardingSettingGetExpiringVppTokenCountRequest.cs
@@ -25,14 +25,14 @@ namespace Microsoft.Graph
         /// <summary>
         /// Issues the GET request.
         /// </summary>
-        System.Threading.Tasks.Task<Int32> GetAsync();
+        System.Threading.Tasks.Task<Int32?> GetAsync();
 
         /// <summary>
         /// Issues the GET request.
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        System.Threading.Tasks.Task<Int32> GetAsync(
+        System.Threading.Tasks.Task<Int32?> GetAsync(
             CancellationToken cancellationToken);
 
 

--- a/src/Microsoft.Graph/Generated/requests/IDeviceManagementScopedForResourceRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/IDeviceManagementScopedForResourceRequest.cs
@@ -25,14 +25,14 @@ namespace Microsoft.Graph
         /// <summary>
         /// Issues the GET request.
         /// </summary>
-        System.Threading.Tasks.Task<bool> GetAsync();
+        System.Threading.Tasks.Task<bool?> GetAsync();
 
         /// <summary>
         /// Issues the GET request.
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        System.Threading.Tasks.Task<bool> GetAsync(
+        System.Threading.Tasks.Task<bool?> GetAsync(
             CancellationToken cancellationToken);
 
 

--- a/src/Microsoft.Graph/Generated/requests/IDeviceManagementVerifyWindowsEnrollmentAutoDiscoveryRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/IDeviceManagementVerifyWindowsEnrollmentAutoDiscoveryRequest.cs
@@ -25,14 +25,14 @@ namespace Microsoft.Graph
         /// <summary>
         /// Issues the GET request.
         /// </summary>
-        System.Threading.Tasks.Task<bool> GetAsync();
+        System.Threading.Tasks.Task<bool?> GetAsync();
 
         /// <summary>
         /// Issues the GET request.
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        System.Threading.Tasks.Task<bool> GetAsync(
+        System.Threading.Tasks.Task<bool?> GetAsync(
             CancellationToken cancellationToken);
 
 

--- a/src/Microsoft.Graph/Generated/requests/IGroupLifecyclePolicyAddGroupRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/IGroupLifecyclePolicyAddGroupRequest.cs
@@ -30,14 +30,14 @@ namespace Microsoft.Graph
         /// <summary>
         /// Issues the POST request.
         /// </summary>
-        System.Threading.Tasks.Task<bool> PostAsync();
+        System.Threading.Tasks.Task<bool?> PostAsync();
 
         /// <summary>
         /// Issues the POST request.
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        System.Threading.Tasks.Task<bool> PostAsync(
+        System.Threading.Tasks.Task<bool?> PostAsync(
             CancellationToken cancellationToken);
 
 

--- a/src/Microsoft.Graph/Generated/requests/IGroupLifecyclePolicyRemoveGroupRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/IGroupLifecyclePolicyRemoveGroupRequest.cs
@@ -30,14 +30,14 @@ namespace Microsoft.Graph
         /// <summary>
         /// Issues the POST request.
         /// </summary>
-        System.Threading.Tasks.Task<bool> PostAsync();
+        System.Threading.Tasks.Task<bool?> PostAsync();
 
         /// <summary>
         /// Issues the POST request.
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        System.Threading.Tasks.Task<bool> PostAsync(
+        System.Threading.Tasks.Task<bool?> PostAsync(
             CancellationToken cancellationToken);
 
 

--- a/src/Microsoft.Graph/Generated/requests/IGroupLifecyclePolicyRenewGroupRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/IGroupLifecyclePolicyRenewGroupRequest.cs
@@ -30,14 +30,14 @@ namespace Microsoft.Graph
         /// <summary>
         /// Issues the POST request.
         /// </summary>
-        System.Threading.Tasks.Task<bool> PostAsync();
+        System.Threading.Tasks.Task<bool?> PostAsync();
 
         /// <summary>
         /// Issues the POST request.
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        System.Threading.Tasks.Task<bool> PostAsync(
+        System.Threading.Tasks.Task<bool?> PostAsync(
             CancellationToken cancellationToken);
 
 

--- a/src/Microsoft.Graph/Generated/requests/IMobileAppGetMobileAppCountRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/IMobileAppGetMobileAppCountRequest.cs
@@ -25,14 +25,14 @@ namespace Microsoft.Graph
         /// <summary>
         /// Issues the GET request.
         /// </summary>
-        System.Threading.Tasks.Task<Int64> GetAsync();
+        System.Threading.Tasks.Task<Int64?> GetAsync();
 
         /// <summary>
         /// Issues the GET request.
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        System.Threading.Tasks.Task<Int64> GetAsync(
+        System.Threading.Tasks.Task<Int64?> GetAsync(
             CancellationToken cancellationToken);
 
 

--- a/src/Microsoft.Graph/Generated/requests/IOrganizationSetMobileDeviceManagementAuthorityRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/IOrganizationSetMobileDeviceManagementAuthorityRequest.cs
@@ -25,14 +25,14 @@ namespace Microsoft.Graph
         /// <summary>
         /// Issues the POST request.
         /// </summary>
-        System.Threading.Tasks.Task<Int32> PostAsync();
+        System.Threading.Tasks.Task<Int32?> PostAsync();
 
         /// <summary>
         /// Issues the POST request.
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        System.Threading.Tasks.Task<Int32> PostAsync(
+        System.Threading.Tasks.Task<Int32?> PostAsync(
             CancellationToken cancellationToken);
 
 

--- a/src/Microsoft.Graph/Generated/requests/IPrivilegedSignupStatusCanSignUpRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/IPrivilegedSignupStatusCanSignUpRequest.cs
@@ -25,14 +25,14 @@ namespace Microsoft.Graph
         /// <summary>
         /// Issues the GET request.
         /// </summary>
-        System.Threading.Tasks.Task<bool> GetAsync();
+        System.Threading.Tasks.Task<bool?> GetAsync();
 
         /// <summary>
         /// Issues the GET request.
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        System.Threading.Tasks.Task<bool> GetAsync(
+        System.Threading.Tasks.Task<bool?> GetAsync(
             CancellationToken cancellationToken);
 
 

--- a/src/Microsoft.Graph/Generated/requests/IPrivilegedSignupStatusIsSignedUpRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/IPrivilegedSignupStatusIsSignedUpRequest.cs
@@ -25,14 +25,14 @@ namespace Microsoft.Graph
         /// <summary>
         /// Issues the GET request.
         /// </summary>
-        System.Threading.Tasks.Task<bool> GetAsync();
+        System.Threading.Tasks.Task<bool?> GetAsync();
 
         /// <summary>
         /// Issues the GET request.
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        System.Threading.Tasks.Task<bool> GetAsync(
+        System.Threading.Tasks.Task<bool?> GetAsync(
             CancellationToken cancellationToken);
 
 

--- a/src/Microsoft.Graph/Generated/requests/IRoleScopeTagHasCustomRoleScopeTagRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/IRoleScopeTagHasCustomRoleScopeTagRequest.cs
@@ -25,14 +25,14 @@ namespace Microsoft.Graph
         /// <summary>
         /// Issues the GET request.
         /// </summary>
-        System.Threading.Tasks.Task<bool> GetAsync();
+        System.Threading.Tasks.Task<bool?> GetAsync();
 
         /// <summary>
         /// Issues the GET request.
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        System.Threading.Tasks.Task<bool> GetAsync(
+        System.Threading.Tasks.Task<bool?> GetAsync(
             CancellationToken cancellationToken);
 
 

--- a/src/Microsoft.Graph/Generated/requests/IUserInvalidateAllRefreshTokensRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/IUserInvalidateAllRefreshTokensRequest.cs
@@ -25,14 +25,14 @@ namespace Microsoft.Graph
         /// <summary>
         /// Issues the POST request.
         /// </summary>
-        System.Threading.Tasks.Task<bool> PostAsync();
+        System.Threading.Tasks.Task<bool?> PostAsync();
 
         /// <summary>
         /// Issues the POST request.
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        System.Threading.Tasks.Task<bool> PostAsync(
+        System.Threading.Tasks.Task<bool?> PostAsync(
             CancellationToken cancellationToken);
 
 

--- a/src/Microsoft.Graph/Generated/requests/IUserIsManagedAppUserBlockedRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/IUserIsManagedAppUserBlockedRequest.cs
@@ -25,14 +25,14 @@ namespace Microsoft.Graph
         /// <summary>
         /// Issues the GET request.
         /// </summary>
-        System.Threading.Tasks.Task<bool> GetAsync();
+        System.Threading.Tasks.Task<bool?> GetAsync();
 
         /// <summary>
         /// Issues the GET request.
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        System.Threading.Tasks.Task<bool> GetAsync(
+        System.Threading.Tasks.Task<bool?> GetAsync(
             CancellationToken cancellationToken);
 
 

--- a/src/Microsoft.Graph/Generated/requests/IUserRevokeSignInSessionsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/IUserRevokeSignInSessionsRequest.cs
@@ -25,14 +25,14 @@ namespace Microsoft.Graph
         /// <summary>
         /// Issues the POST request.
         /// </summary>
-        System.Threading.Tasks.Task<bool> PostAsync();
+        System.Threading.Tasks.Task<bool?> PostAsync();
 
         /// <summary>
         /// Issues the POST request.
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        System.Threading.Tasks.Task<bool> PostAsync(
+        System.Threading.Tasks.Task<bool?> PostAsync(
             CancellationToken cancellationToken);
 
 

--- a/src/Microsoft.Graph/Generated/requests/IWorkbookChartCountRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/IWorkbookChartCountRequest.cs
@@ -25,14 +25,14 @@ namespace Microsoft.Graph
         /// <summary>
         /// Issues the GET request.
         /// </summary>
-        System.Threading.Tasks.Task<Int32> GetAsync();
+        System.Threading.Tasks.Task<Int32?> GetAsync();
 
         /// <summary>
         /// Issues the GET request.
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        System.Threading.Tasks.Task<Int32> GetAsync(
+        System.Threading.Tasks.Task<Int32?> GetAsync(
             CancellationToken cancellationToken);
 
 

--- a/src/Microsoft.Graph/Generated/requests/IWorkbookChartPointCountRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/IWorkbookChartPointCountRequest.cs
@@ -25,14 +25,14 @@ namespace Microsoft.Graph
         /// <summary>
         /// Issues the GET request.
         /// </summary>
-        System.Threading.Tasks.Task<Int32> GetAsync();
+        System.Threading.Tasks.Task<Int32?> GetAsync();
 
         /// <summary>
         /// Issues the GET request.
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        System.Threading.Tasks.Task<Int32> GetAsync(
+        System.Threading.Tasks.Task<Int32?> GetAsync(
             CancellationToken cancellationToken);
 
 

--- a/src/Microsoft.Graph/Generated/requests/IWorkbookChartSeriesCountRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/IWorkbookChartSeriesCountRequest.cs
@@ -25,14 +25,14 @@ namespace Microsoft.Graph
         /// <summary>
         /// Issues the GET request.
         /// </summary>
-        System.Threading.Tasks.Task<Int32> GetAsync();
+        System.Threading.Tasks.Task<Int32?> GetAsync();
 
         /// <summary>
         /// Issues the GET request.
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        System.Threading.Tasks.Task<Int32> GetAsync(
+        System.Threading.Tasks.Task<Int32?> GetAsync(
             CancellationToken cancellationToken);
 
 

--- a/src/Microsoft.Graph/Generated/requests/IWorkbookRangeBorderCountRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/IWorkbookRangeBorderCountRequest.cs
@@ -25,14 +25,14 @@ namespace Microsoft.Graph
         /// <summary>
         /// Issues the GET request.
         /// </summary>
-        System.Threading.Tasks.Task<Int32> GetAsync();
+        System.Threading.Tasks.Task<Int32?> GetAsync();
 
         /// <summary>
         /// Issues the GET request.
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        System.Threading.Tasks.Task<Int32> GetAsync(
+        System.Threading.Tasks.Task<Int32?> GetAsync(
             CancellationToken cancellationToken);
 
 

--- a/src/Microsoft.Graph/Generated/requests/IWorkbookTableColumnCountRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/IWorkbookTableColumnCountRequest.cs
@@ -25,14 +25,14 @@ namespace Microsoft.Graph
         /// <summary>
         /// Issues the GET request.
         /// </summary>
-        System.Threading.Tasks.Task<Int32> GetAsync();
+        System.Threading.Tasks.Task<Int32?> GetAsync();
 
         /// <summary>
         /// Issues the GET request.
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        System.Threading.Tasks.Task<Int32> GetAsync(
+        System.Threading.Tasks.Task<Int32?> GetAsync(
             CancellationToken cancellationToken);
 
 

--- a/src/Microsoft.Graph/Generated/requests/IWorkbookTableCountRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/IWorkbookTableCountRequest.cs
@@ -25,14 +25,14 @@ namespace Microsoft.Graph
         /// <summary>
         /// Issues the GET request.
         /// </summary>
-        System.Threading.Tasks.Task<Int32> GetAsync();
+        System.Threading.Tasks.Task<Int32?> GetAsync();
 
         /// <summary>
         /// Issues the GET request.
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        System.Threading.Tasks.Task<Int32> GetAsync(
+        System.Threading.Tasks.Task<Int32?> GetAsync(
             CancellationToken cancellationToken);
 
 

--- a/src/Microsoft.Graph/Generated/requests/IWorkbookTableRowCountRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/IWorkbookTableRowCountRequest.cs
@@ -25,14 +25,14 @@ namespace Microsoft.Graph
         /// <summary>
         /// Issues the GET request.
         /// </summary>
-        System.Threading.Tasks.Task<Int32> GetAsync();
+        System.Threading.Tasks.Task<Int32?> GetAsync();
 
         /// <summary>
         /// Issues the GET request.
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        System.Threading.Tasks.Task<Int32> GetAsync(
+        System.Threading.Tasks.Task<Int32?> GetAsync(
             CancellationToken cancellationToken);
 
 

--- a/src/Microsoft.Graph/Generated/requests/ManagedDeviceGetFileVaultKeyRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ManagedDeviceGetFileVaultKeyRequest.cs
@@ -44,11 +44,12 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<string> GetAsync(
+        public async System.Threading.Tasks.Task<string> GetAsync(
             CancellationToken cancellationToken)
         {
             this.Method = "GET";
-            return this.SendAsync<string>(null, cancellationToken);
+            var response = await this.SendAsync<ODataMethodStringResponse>(null, cancellationToken);
+            return response.Value;
         }
 
 

--- a/src/Microsoft.Graph/Generated/requests/MobileAppGetMobileAppCountRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/MobileAppGetMobileAppCountRequest.cs
@@ -44,11 +44,12 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Int64> GetAsync(
+        public async System.Threading.Tasks.Task<Int64> GetAsync(
             CancellationToken cancellationToken)
         {
             this.Method = "GET";
-            return this.SendAsync<Int64>(null, cancellationToken);
+            var response = await this.SendAsync<ODataMethodLongResponse>(null, cancellationToken);
+            return response.Value;
         }
 
 

--- a/src/Microsoft.Graph/Generated/requests/MobileAppGetMobileAppCountRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/MobileAppGetMobileAppCountRequest.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Issues the GET request.
         /// </summary>
-        public System.Threading.Tasks.Task<Int64> GetAsync()
+        public System.Threading.Tasks.Task<Int64?> GetAsync()
         {
             return this.GetAsync(CancellationToken.None);
         }
@@ -44,7 +44,7 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<Int64> GetAsync(
+        public async System.Threading.Tasks.Task<Int64?> GetAsync(
             CancellationToken cancellationToken)
         {
             this.Method = "GET";

--- a/src/Microsoft.Graph/Generated/requests/MobileAppValidateXmlRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/MobileAppValidateXmlRequest.cs
@@ -51,11 +51,12 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<string> PostAsync(
+        public async System.Threading.Tasks.Task<string> PostAsync(
             CancellationToken cancellationToken)
         {
             this.Method = "POST";
-            return this.SendAsync<string>(this.RequestBody, cancellationToken);
+            var response = await this.SendAsync<ODataMethodStringResponse>(this.RequestBody, cancellationToken);
+            return response.Value;
         }
 
 

--- a/src/Microsoft.Graph/Generated/requests/OrganizationSetMobileDeviceManagementAuthorityRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/OrganizationSetMobileDeviceManagementAuthorityRequest.cs
@@ -44,11 +44,12 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Int32> PostAsync(
+        public async System.Threading.Tasks.Task<Int32> PostAsync(
             CancellationToken cancellationToken)
         {
             this.Method = "POST";
-            return this.SendAsync<Int32>(null, cancellationToken);
+            var response = await this.SendAsync<ODataMethodIntResponse>(null, cancellationToken);
+            return response.Value;
         }
 
 

--- a/src/Microsoft.Graph/Generated/requests/OrganizationSetMobileDeviceManagementAuthorityRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/OrganizationSetMobileDeviceManagementAuthorityRequest.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Issues the POST request.
         /// </summary>
-        public System.Threading.Tasks.Task<Int32> PostAsync()
+        public System.Threading.Tasks.Task<Int32?> PostAsync()
         {
             return this.PostAsync(CancellationToken.None);
         }
@@ -44,7 +44,7 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<Int32> PostAsync(
+        public async System.Threading.Tasks.Task<Int32?> PostAsync(
             CancellationToken cancellationToken)
         {
             this.Method = "POST";

--- a/src/Microsoft.Graph/Generated/requests/PrivilegedSignupStatusCanSignUpRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/PrivilegedSignupStatusCanSignUpRequest.cs
@@ -44,11 +44,12 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<bool> GetAsync(
+        public async System.Threading.Tasks.Task<bool> GetAsync(
             CancellationToken cancellationToken)
         {
             this.Method = "GET";
-            return this.SendAsync<bool>(null, cancellationToken);
+            var response = await this.SendAsync<ODataMethodBooleanResponse>(null, cancellationToken);
+            return response.Value;
         }
 
 

--- a/src/Microsoft.Graph/Generated/requests/PrivilegedSignupStatusCanSignUpRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/PrivilegedSignupStatusCanSignUpRequest.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Issues the GET request.
         /// </summary>
-        public System.Threading.Tasks.Task<bool> GetAsync()
+        public System.Threading.Tasks.Task<bool?> GetAsync()
         {
             return this.GetAsync(CancellationToken.None);
         }
@@ -44,7 +44,7 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<bool> GetAsync(
+        public async System.Threading.Tasks.Task<bool?> GetAsync(
             CancellationToken cancellationToken)
         {
             this.Method = "GET";

--- a/src/Microsoft.Graph/Generated/requests/PrivilegedSignupStatusIsSignedUpRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/PrivilegedSignupStatusIsSignedUpRequest.cs
@@ -44,11 +44,12 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<bool> GetAsync(
+        public async System.Threading.Tasks.Task<bool> GetAsync(
             CancellationToken cancellationToken)
         {
             this.Method = "GET";
-            return this.SendAsync<bool>(null, cancellationToken);
+            var response = await this.SendAsync<ODataMethodBooleanResponse>(null, cancellationToken);
+            return response.Value;
         }
 
 

--- a/src/Microsoft.Graph/Generated/requests/PrivilegedSignupStatusIsSignedUpRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/PrivilegedSignupStatusIsSignedUpRequest.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Issues the GET request.
         /// </summary>
-        public System.Threading.Tasks.Task<bool> GetAsync()
+        public System.Threading.Tasks.Task<bool?> GetAsync()
         {
             return this.GetAsync(CancellationToken.None);
         }
@@ -44,7 +44,7 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<bool> GetAsync(
+        public async System.Threading.Tasks.Task<bool?> GetAsync(
             CancellationToken cancellationToken)
         {
             this.Method = "GET";

--- a/src/Microsoft.Graph/Generated/requests/RoleScopeTagHasCustomRoleScopeTagRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/RoleScopeTagHasCustomRoleScopeTagRequest.cs
@@ -44,11 +44,12 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<bool> GetAsync(
+        public async System.Threading.Tasks.Task<bool> GetAsync(
             CancellationToken cancellationToken)
         {
             this.Method = "GET";
-            return this.SendAsync<bool>(null, cancellationToken);
+            var response = await this.SendAsync<ODataMethodBooleanResponse>(null, cancellationToken);
+            return response.Value;
         }
 
 

--- a/src/Microsoft.Graph/Generated/requests/RoleScopeTagHasCustomRoleScopeTagRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/RoleScopeTagHasCustomRoleScopeTagRequest.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Issues the GET request.
         /// </summary>
-        public System.Threading.Tasks.Task<bool> GetAsync()
+        public System.Threading.Tasks.Task<bool?> GetAsync()
         {
             return this.GetAsync(CancellationToken.None);
         }
@@ -44,7 +44,7 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<bool> GetAsync(
+        public async System.Threading.Tasks.Task<bool?> GetAsync(
             CancellationToken cancellationToken)
         {
             this.Method = "GET";

--- a/src/Microsoft.Graph/Generated/requests/SynchronizationPingRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/SynchronizationPingRequest.cs
@@ -44,11 +44,12 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<string> GetAsync(
+        public async System.Threading.Tasks.Task<string> GetAsync(
             CancellationToken cancellationToken)
         {
             this.Method = "GET";
-            return this.SendAsync<string>(null, cancellationToken);
+            var response = await this.SendAsync<ODataMethodStringResponse>(null, cancellationToken);
+            return response.Value;
         }
 
 

--- a/src/Microsoft.Graph/Generated/requests/UserInvalidateAllRefreshTokensRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/UserInvalidateAllRefreshTokensRequest.cs
@@ -44,11 +44,12 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<bool> PostAsync(
+        public async System.Threading.Tasks.Task<bool> PostAsync(
             CancellationToken cancellationToken)
         {
             this.Method = "POST";
-            return this.SendAsync<bool>(null, cancellationToken);
+            var response = await this.SendAsync<ODataMethodBooleanResponse>(null, cancellationToken);
+            return response.Value;
         }
 
 

--- a/src/Microsoft.Graph/Generated/requests/UserInvalidateAllRefreshTokensRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/UserInvalidateAllRefreshTokensRequest.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Issues the POST request.
         /// </summary>
-        public System.Threading.Tasks.Task<bool> PostAsync()
+        public System.Threading.Tasks.Task<bool?> PostAsync()
         {
             return this.PostAsync(CancellationToken.None);
         }
@@ -44,7 +44,7 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<bool> PostAsync(
+        public async System.Threading.Tasks.Task<bool?> PostAsync(
             CancellationToken cancellationToken)
         {
             this.Method = "POST";

--- a/src/Microsoft.Graph/Generated/requests/UserIsManagedAppUserBlockedRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/UserIsManagedAppUserBlockedRequest.cs
@@ -44,11 +44,12 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<bool> GetAsync(
+        public async System.Threading.Tasks.Task<bool> GetAsync(
             CancellationToken cancellationToken)
         {
             this.Method = "GET";
-            return this.SendAsync<bool>(null, cancellationToken);
+            var response = await this.SendAsync<ODataMethodBooleanResponse>(null, cancellationToken);
+            return response.Value;
         }
 
 

--- a/src/Microsoft.Graph/Generated/requests/UserIsManagedAppUserBlockedRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/UserIsManagedAppUserBlockedRequest.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Issues the GET request.
         /// </summary>
-        public System.Threading.Tasks.Task<bool> GetAsync()
+        public System.Threading.Tasks.Task<bool?> GetAsync()
         {
             return this.GetAsync(CancellationToken.None);
         }
@@ -44,7 +44,7 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<bool> GetAsync(
+        public async System.Threading.Tasks.Task<bool?> GetAsync(
             CancellationToken cancellationToken)
         {
             this.Method = "GET";

--- a/src/Microsoft.Graph/Generated/requests/UserRevokeSignInSessionsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/UserRevokeSignInSessionsRequest.cs
@@ -44,11 +44,12 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<bool> PostAsync(
+        public async System.Threading.Tasks.Task<bool> PostAsync(
             CancellationToken cancellationToken)
         {
             this.Method = "POST";
-            return this.SendAsync<bool>(null, cancellationToken);
+            var response = await this.SendAsync<ODataMethodBooleanResponse>(null, cancellationToken);
+            return response.Value;
         }
 
 

--- a/src/Microsoft.Graph/Generated/requests/UserRevokeSignInSessionsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/UserRevokeSignInSessionsRequest.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Issues the POST request.
         /// </summary>
-        public System.Threading.Tasks.Task<bool> PostAsync()
+        public System.Threading.Tasks.Task<bool?> PostAsync()
         {
             return this.PostAsync(CancellationToken.None);
         }
@@ -44,7 +44,7 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<bool> PostAsync(
+        public async System.Threading.Tasks.Task<bool?> PostAsync(
             CancellationToken cancellationToken)
         {
             this.Method = "POST";

--- a/src/Microsoft.Graph/Generated/requests/WorkbookChartCountRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookChartCountRequest.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Issues the GET request.
         /// </summary>
-        public System.Threading.Tasks.Task<Int32> GetAsync()
+        public System.Threading.Tasks.Task<Int32?> GetAsync()
         {
             return this.GetAsync(CancellationToken.None);
         }
@@ -44,7 +44,7 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<Int32> GetAsync(
+        public async System.Threading.Tasks.Task<Int32?> GetAsync(
             CancellationToken cancellationToken)
         {
             this.Method = "GET";

--- a/src/Microsoft.Graph/Generated/requests/WorkbookChartCountRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookChartCountRequest.cs
@@ -44,11 +44,12 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Int32> GetAsync(
+        public async System.Threading.Tasks.Task<Int32> GetAsync(
             CancellationToken cancellationToken)
         {
             this.Method = "GET";
-            return this.SendAsync<Int32>(null, cancellationToken);
+            var response = await this.SendAsync<ODataMethodIntResponse>(null, cancellationToken);
+            return response.Value;
         }
 
 

--- a/src/Microsoft.Graph/Generated/requests/WorkbookChartImageRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookChartImageRequest.cs
@@ -44,11 +44,12 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<string> GetAsync(
+        public async System.Threading.Tasks.Task<string> GetAsync(
             CancellationToken cancellationToken)
         {
             this.Method = "GET";
-            return this.SendAsync<string>(null, cancellationToken);
+            var response = await this.SendAsync<ODataMethodStringResponse>(null, cancellationToken);
+            return response.Value;
         }
 
 

--- a/src/Microsoft.Graph/Generated/requests/WorkbookChartPointCountRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookChartPointCountRequest.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Issues the GET request.
         /// </summary>
-        public System.Threading.Tasks.Task<Int32> GetAsync()
+        public System.Threading.Tasks.Task<Int32?> GetAsync()
         {
             return this.GetAsync(CancellationToken.None);
         }
@@ -44,7 +44,7 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<Int32> GetAsync(
+        public async System.Threading.Tasks.Task<Int32?> GetAsync(
             CancellationToken cancellationToken)
         {
             this.Method = "GET";

--- a/src/Microsoft.Graph/Generated/requests/WorkbookChartPointCountRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookChartPointCountRequest.cs
@@ -44,11 +44,12 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Int32> GetAsync(
+        public async System.Threading.Tasks.Task<Int32> GetAsync(
             CancellationToken cancellationToken)
         {
             this.Method = "GET";
-            return this.SendAsync<Int32>(null, cancellationToken);
+            var response = await this.SendAsync<ODataMethodIntResponse>(null, cancellationToken);
+            return response.Value;
         }
 
 

--- a/src/Microsoft.Graph/Generated/requests/WorkbookChartSeriesCountRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookChartSeriesCountRequest.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Issues the GET request.
         /// </summary>
-        public System.Threading.Tasks.Task<Int32> GetAsync()
+        public System.Threading.Tasks.Task<Int32?> GetAsync()
         {
             return this.GetAsync(CancellationToken.None);
         }
@@ -44,7 +44,7 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<Int32> GetAsync(
+        public async System.Threading.Tasks.Task<Int32?> GetAsync(
             CancellationToken cancellationToken)
         {
             this.Method = "GET";

--- a/src/Microsoft.Graph/Generated/requests/WorkbookChartSeriesCountRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookChartSeriesCountRequest.cs
@@ -44,11 +44,12 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Int32> GetAsync(
+        public async System.Threading.Tasks.Task<Int32> GetAsync(
             CancellationToken cancellationToken)
         {
             this.Method = "GET";
-            return this.SendAsync<Int32>(null, cancellationToken);
+            var response = await this.SendAsync<ODataMethodIntResponse>(null, cancellationToken);
+            return response.Value;
         }
 
 

--- a/src/Microsoft.Graph/Generated/requests/WorkbookRangeBorderCountRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookRangeBorderCountRequest.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Issues the GET request.
         /// </summary>
-        public System.Threading.Tasks.Task<Int32> GetAsync()
+        public System.Threading.Tasks.Task<Int32?> GetAsync()
         {
             return this.GetAsync(CancellationToken.None);
         }
@@ -44,7 +44,7 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<Int32> GetAsync(
+        public async System.Threading.Tasks.Task<Int32?> GetAsync(
             CancellationToken cancellationToken)
         {
             this.Method = "GET";

--- a/src/Microsoft.Graph/Generated/requests/WorkbookRangeBorderCountRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookRangeBorderCountRequest.cs
@@ -44,11 +44,12 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Int32> GetAsync(
+        public async System.Threading.Tasks.Task<Int32> GetAsync(
             CancellationToken cancellationToken)
         {
             this.Method = "GET";
-            return this.SendAsync<Int32>(null, cancellationToken);
+            var response = await this.SendAsync<ODataMethodIntResponse>(null, cancellationToken);
+            return response.Value;
         }
 
 

--- a/src/Microsoft.Graph/Generated/requests/WorkbookTableColumnCountRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookTableColumnCountRequest.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Issues the GET request.
         /// </summary>
-        public System.Threading.Tasks.Task<Int32> GetAsync()
+        public System.Threading.Tasks.Task<Int32?> GetAsync()
         {
             return this.GetAsync(CancellationToken.None);
         }
@@ -44,7 +44,7 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<Int32> GetAsync(
+        public async System.Threading.Tasks.Task<Int32?> GetAsync(
             CancellationToken cancellationToken)
         {
             this.Method = "GET";

--- a/src/Microsoft.Graph/Generated/requests/WorkbookTableColumnCountRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookTableColumnCountRequest.cs
@@ -44,11 +44,12 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Int32> GetAsync(
+        public async System.Threading.Tasks.Task<Int32> GetAsync(
             CancellationToken cancellationToken)
         {
             this.Method = "GET";
-            return this.SendAsync<Int32>(null, cancellationToken);
+            var response = await this.SendAsync<ODataMethodIntResponse>(null, cancellationToken);
+            return response.Value;
         }
 
 

--- a/src/Microsoft.Graph/Generated/requests/WorkbookTableCountRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookTableCountRequest.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Issues the GET request.
         /// </summary>
-        public System.Threading.Tasks.Task<Int32> GetAsync()
+        public System.Threading.Tasks.Task<Int32?> GetAsync()
         {
             return this.GetAsync(CancellationToken.None);
         }
@@ -44,7 +44,7 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<Int32> GetAsync(
+        public async System.Threading.Tasks.Task<Int32?> GetAsync(
             CancellationToken cancellationToken)
         {
             this.Method = "GET";

--- a/src/Microsoft.Graph/Generated/requests/WorkbookTableCountRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookTableCountRequest.cs
@@ -44,11 +44,12 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Int32> GetAsync(
+        public async System.Threading.Tasks.Task<Int32> GetAsync(
             CancellationToken cancellationToken)
         {
             this.Method = "GET";
-            return this.SendAsync<Int32>(null, cancellationToken);
+            var response = await this.SendAsync<ODataMethodIntResponse>(null, cancellationToken);
+            return response.Value;
         }
 
 

--- a/src/Microsoft.Graph/Generated/requests/WorkbookTableRowCountRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookTableRowCountRequest.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Issues the GET request.
         /// </summary>
-        public System.Threading.Tasks.Task<Int32> GetAsync()
+        public System.Threading.Tasks.Task<Int32?> GetAsync()
         {
             return this.GetAsync(CancellationToken.None);
         }
@@ -44,7 +44,7 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<Int32> GetAsync(
+        public async System.Threading.Tasks.Task<Int32?> GetAsync(
             CancellationToken cancellationToken)
         {
             this.Method = "GET";

--- a/src/Microsoft.Graph/Generated/requests/WorkbookTableRowCountRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookTableRowCountRequest.cs
@@ -44,11 +44,12 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Int32> GetAsync(
+        public async System.Threading.Tasks.Task<Int32> GetAsync(
             CancellationToken cancellationToken)
         {
             this.Method = "GET";
-            return this.SendAsync<Int32>(null, cancellationToken);
+            var response = await this.SendAsync<ODataMethodIntResponse>(null, cancellationToken);
+            return response.Value;
         }
 
 

--- a/src/Microsoft.Graph/Microsoft.Graph.Beta.csproj
+++ b/src/Microsoft.Graph/Microsoft.Graph.Beta.csproj
@@ -38,7 +38,7 @@
     <None Include=".\..\..\LICENSE.txt" Pack="true" PackagePath="" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Graph.Core" Version="3.*" />
+    <PackageReference Include="Microsoft.Graph.Core" Version="1.*" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netnet461' ">
     <Reference Include="System" />

--- a/src/Microsoft.Graph/Microsoft.Graph.Beta.csproj
+++ b/src/Microsoft.Graph/Microsoft.Graph.Beta.csproj
@@ -38,7 +38,7 @@
     <None Include=".\..\..\LICENSE.txt" Pack="true" PackagePath="" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Graph.Core" Version="[1.19.0,2)" />
+    <PackageReference Include="Microsoft.Graph.Core" Version="3.*" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netnet461' ">
     <Reference Include="System" />


### PR DESCRIPTION
Methods that return primitives returned JSON objects and not just the OData primitive values. An update needs to occur in the generator and core to support this scenario.

Depends on https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/135. Tests won't pass until this is published.