### PR TITLE
Update minimum netframework to v4.6.2 in feature/2.0

### DIFF
--- a/src/Microsoft.Graph/Microsoft.Graph.Beta.csproj
+++ b/src/Microsoft.Graph/Microsoft.Graph.Beta.csproj
@@ -4,7 +4,7 @@
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <AssemblyTitle>Microsoft Graph Beta Client Library</AssemblyTitle>
     <Authors>Microsoft</Authors>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <PreserveCompilationContext>false</PreserveCompilationContext>
     <AssemblyName>Microsoft.Graph.Beta</AssemblyName>
@@ -43,7 +43,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Graph.Core" Version="2.0.0-preview.7" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
     <Reference Include="System" />
     <Reference Include="System.Net.Http" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/Microsoft.Graph/Microsoft.Graph.Beta.csproj
+++ b/src/Microsoft.Graph/Microsoft.Graph.Beta.csproj
@@ -23,6 +23,10 @@
     <PackageReleaseNotes>
 - [Breaking change] Update Microsoft.Graph.Core to v2.0.0
 - [Breaking change] Replace Newtosoft.Json with System.Text.Json
+- Add request builder methods for GraphResponse
+- [Breaking change] Removed IGraphServiceClient interface
+- Added GraphServiceClient constructor that accepts TokenCredential instance
+- [Breaking change] Bump minimun .NetFramework version to 4.6.2 from 4.6.1
     </PackageReleaseNotes>
     <!-- edit this value to change the current major.minor.patch version -->
     <VersionPrefix>4.0.0</VersionPrefix>


### PR DESCRIPTION
This PR is part of https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/issues/219

This comes in as a new requirement as 4.6.1 is coming to EOL soon.

This PR updates the release notes in the csproj to capture recent updates to the branch