### PR TITLE
Migrate release build definition and build snupkg files as part of the pipeline

### DIFF
--- a/pipelines/ci-build.yml
+++ b/pipelines/ci-build.yml
@@ -165,7 +165,7 @@ steps:
     command: pack
     packagesToPack: '**\Microsoft.Graph.Beta.csproj'
     nobuild: true
-    includesymbols: true
+    arguments: '/p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg'
 
 - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
   displayName: 'ESRP NuGet CodeSigning'

--- a/pipelines/ci-build.yml
+++ b/pipelines/ci-build.yml
@@ -1,3 +1,13 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+name: '.NET Beta Service Library - CI'
+trigger:
+  branches:
+    include:
+      - master
+
+
 pool:
   name: Hosted Windows 2019 with VS2019
   demands:
@@ -196,4 +206,3 @@ steps:
   displayName: 'Publish Artifact: Microsoft.Graph.Beta.nupkg and release pipeline scripts'
 
 #Task group has not been exported, task groups are not supported yet
-

--- a/pipelines/ci-build.yml
+++ b/pipelines/ci-build.yml
@@ -159,13 +159,8 @@ steps:
      ]
     SessionTimeout: 20
 
-- task: DotNetCoreCLI@2
-  displayName: 'dotnet pack (no build, create NuGet)'
-  inputs:
-    command: pack
-    packagesToPack: '**\Microsoft.Graph.Beta.csproj'
-    nobuild: true
-    arguments: '/p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg'
+- powershell: |
+    dotnet pack $env:BUILD_SOURCESDIRECTORY/src/Microsoft.Graph/Microsoft.Graph.Beta.csproj /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg --no-build --output $env:BUILD_ARTIFACTSTAGINGDIRECTORY
 
 - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
   displayName: 'ESRP NuGet CodeSigning'

--- a/pipelines/ci-build.yml
+++ b/pipelines/ci-build.yml
@@ -167,7 +167,7 @@ steps:
   inputs:
     ConnectedServiceName: 'microsoftgraph ESRP CodeSign DLL and NuGet (AKV)'
     FolderPath: '$(Build.ArtifactStagingDirectory)'
-    Pattern: '*.nupkg'
+    Pattern: '*nupkg'
     signConfigType: inlineSignParams
     inlineOperation: |
           [

--- a/pipelines/ci-build.yml
+++ b/pipelines/ci-build.yml
@@ -160,7 +160,9 @@ steps:
     SessionTimeout: 20
 
 - powershell: |
-    dotnet pack $env:BUILD_SOURCESDIRECTORY/src/Microsoft.Graph/Microsoft.Graph.Beta.csproj /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg --no-build --output $env:BUILD_ARTIFACTSTAGINGDIRECTORY
+    dotnet pack $env:BUILD_SOURCESDIRECTORY/src/Microsoft.Graph/Microsoft.Graph.Beta.csproj /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg --no-build --output $env:BUILD_ARTIFACTSTAGINGDIRECTORY --configuration $env:BUILD_CONFIGURATION
+  env:
+    BUILD_CONFIGURATION: $(BuildConfiguration)
 
 - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
   displayName: 'ESRP NuGet CodeSigning'

--- a/pipelines/ci-build.yml
+++ b/pipelines/ci-build.yml
@@ -1,12 +1,11 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-name: '.NET Beta Service Library - CI'
+name: $(BuildDefinitionName)_$(SourceBranchName)_$(Date:yyyyMMdd)$(Rev:.r)
 trigger:
   branches:
     include:
       - master
-
 
 pool:
   name: Hosted Windows 2019 with VS2019

--- a/pipelines/ci-build.yml
+++ b/pipelines/ci-build.yml
@@ -165,8 +165,7 @@ steps:
     command: pack
     packagesToPack: '**\Microsoft.Graph.Beta.csproj'
     nobuild: true
-    includesymbols: true
-    arguments: '-p:SymbolPackageFormat=snupkg'
+    arguments: '-p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg'
 
 - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
   displayName: 'ESRP NuGet CodeSigning'

--- a/pipelines/ci-build.yml
+++ b/pipelines/ci-build.yml
@@ -166,6 +166,7 @@ steps:
     packagesToPack: '**\Microsoft.Graph.Beta.csproj'
     nobuild: true
     includesymbols: true
+    arguments: '-p:SymbolPackageFormat=snupkg'
 
 - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
   displayName: 'ESRP NuGet CodeSigning'

--- a/pipelines/ci-build.yml
+++ b/pipelines/ci-build.yml
@@ -9,9 +9,6 @@ trigger:
 
 pool:
   name: Hosted Windows 2019 with VS2019
-  demands:
-  - msbuild
-  - vstest
 
 variables:
   BuildConfiguration: 'release'
@@ -22,36 +19,11 @@ steps:
   inputs:
     debugMode: false
 
-- task: NuGetCommand@2
-  displayName: 'NuGet restore'
-  enabled: false
-
 - task: DotNetCoreCLI@2
   displayName: 'dotnet restore'
   inputs:
     command: restore
     projects: '**/*.csproj'
-
-- task: MSBuild@1
-  displayName: 'Build solution to run unit test'
-  inputs:
-    configuration: release
-    clean: true
-
-- task: VSTest@2
-  displayName: 'Run enabled tests'
-  inputs:
-    testAssemblyVer2: |
-     **\*.Test.dll
-     !*testhost.dll
-     !**\*testhost.dll
-     !**\*Exceptions.Handling.Tests.dll
-     !**\obj\**
-     !**\xunit.runner.visualstudio.testadapter.dll
-     !**\xunit.runner.visualstudio.dotnetcore.testadapter.dll
-    otherConsoleOptions: '/Framework:.NETCoreApp,Version=v3.1 /logger:console;verbosity="normal"'
-    configuration: release
-    diagnosticsEnabled: True
 
 - powershell: |
    # This allows us to not have to checkin .csproj files with DelaySign and SignAssembly set to to true. If the flag is set,
@@ -85,6 +57,13 @@ steps:
   inputs:
     projects: '$(Build.SourcesDirectory)\src\Microsoft.Graph\Microsoft.Graph.Beta.csproj'
     arguments: '-c $(BuildConfiguration) --no-incremental'
+
+- task: DotNetCoreCLI@2
+  displayName: 'run tests'
+  inputs:
+    command: 'test'
+    projects: 'tests/Microsoft.Graph.DotnetCore.Test/Microsoft.Graph.DotnetCore.Test.csproj'
+    arguments: '--configuration $(BuildConfiguration) --verbosity normal'
 
 - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
   displayName: 'ESRP DLL Strong Name (Microsoft.Graph.Beta)'
@@ -159,10 +138,12 @@ steps:
      ]
     SessionTimeout: 20
 
+# arguments are not parsed in DotNetCoreCLI@2 task for `pack` command, that's why we have a custom pack command here
 - powershell: |
     dotnet pack $env:BUILD_SOURCESDIRECTORY/src/Microsoft.Graph/Microsoft.Graph.Beta.csproj /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg --no-build --output $env:BUILD_ARTIFACTSTAGINGDIRECTORY --configuration $env:BUILD_CONFIGURATION
   env:
     BUILD_CONFIGURATION: $(BuildConfiguration)
+  displayName: 'dotnet pack'
 
 - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
   displayName: 'ESRP NuGet CodeSigning'

--- a/pipelines/ci-build.yml
+++ b/pipelines/ci-build.yml
@@ -8,7 +8,7 @@ trigger:
       - master
 
 pool:
-  name: Hosted Windows 2019 with VS2019
+  vmImage: 'windows-latest'
 
 variables:
   BuildConfiguration: 'release'

--- a/pipelines/ci-build.yml
+++ b/pipelines/ci-build.yml
@@ -1,0 +1,199 @@
+pool:
+  name: Hosted Windows 2019 with VS2019
+  demands:
+  - msbuild
+  - vstest
+
+variables:
+  BuildConfiguration: 'release'
+
+steps:
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@2
+  displayName: 'Run CredScan'
+  inputs:
+    debugMode: false
+
+- task: NuGetCommand@2
+  displayName: 'NuGet restore'
+  enabled: false
+
+- task: DotNetCoreCLI@2
+  displayName: 'dotnet restore'
+  inputs:
+    command: restore
+    projects: '**/*.csproj'
+
+- task: MSBuild@1
+  displayName: 'Build solution to run unit test'
+  inputs:
+    configuration: release
+    clean: true
+
+- task: VSTest@2
+  displayName: 'Run enabled tests'
+  inputs:
+    testAssemblyVer2: |
+     **\*.Test.dll
+     !*testhost.dll
+     !**\*testhost.dll
+     !**\*Exceptions.Handling.Tests.dll
+     !**\obj\**
+     !**\xunit.runner.visualstudio.testadapter.dll
+     !**\xunit.runner.visualstudio.dotnetcore.testadapter.dll
+    otherConsoleOptions: '/Framework:.NETCoreApp,Version=v3.1 /logger:console;verbosity="normal"'
+    configuration: release
+    diagnosticsEnabled: True
+
+- powershell: |
+   # This allows us to not have to checkin .csproj files with DelaySign and SignAssembly set to to true. If the flag is set,
+   # then project is not debuggable with SignAssembly set to true.
+   # Assumption: working directory is /src/
+
+   $csprojPaths = @(".\Microsoft.Graph\Microsoft.Graph.Beta.csproj")
+
+   foreach ($csprojPath in $csprojPaths) {
+
+       $doc = New-Object System.Xml.XmlDocument
+       $doc.Load($csprojPath)
+
+       # Set the DelaySign element to 'true' so that delay signing is set.
+       $delaySign = $doc.SelectSingleNode("//DelaySign");
+       $delaySign.'#text'= "true"
+
+       # Set the SignAssembly element to 'true' so that we can sign the assemblies.
+       $signAssembly = $doc.SelectSingleNode("//SignAssembly");
+       $signAssembly.'#text'= "true"
+
+       $doc.Save($csprojPath);
+   }
+
+   Write-Host "Updated the .csproj files so that we can sign the built assemblies."
+  workingDirectory: src
+  displayName: 'Set project ready to sign'
+
+- task: DotNetCoreCLI@2
+  displayName: 'dotnet build'
+  inputs:
+    projects: '$(Build.SourcesDirectory)\src\Microsoft.Graph\Microsoft.Graph.Beta.csproj'
+    arguments: '-c $(BuildConfiguration) --no-incremental'
+
+- task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+  displayName: 'ESRP DLL Strong Name (Microsoft.Graph.Beta)'
+  inputs:
+    ConnectedServiceName: 'microsoftgraph ESRP CodeSign DLL and NuGet (AKV)'
+    FolderPath: src/Microsoft.Graph/bin/release
+    Pattern: Microsoft.Graph.Beta.dll
+    signConfigType: inlineSignParams
+    inlineOperation: |
+     [
+         {
+             "keyCode": "CP-233863-SN",
+             "operationSetCode": "StrongNameSign",
+             "parameters": [],
+             "toolName": "sign",
+             "toolVersion": "1.0"
+         },
+         {
+             "keyCode": "CP-233863-SN",
+             "operationSetCode": "StrongNameVerify",
+             "parameters": [],
+             "toolName": "sign",
+             "toolVersion": "1.0"
+         }
+     ]
+    SessionTimeout: 20
+
+- task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+  displayName: 'ESRP DLL CodeSigning (Microsoft.Graph.Beta)'
+  inputs:
+    ConnectedServiceName: 'microsoftgraph ESRP CodeSign DLL and NuGet (AKV)'
+    FolderPath: src/Microsoft.Graph/bin/release
+    Pattern: Microsoft.Graph.Beta.dll
+    signConfigType: inlineSignParams
+    inlineOperation: |
+     [
+         {
+             "keyCode": "CP-230012",
+             "operationSetCode": "SigntoolSign",
+             "parameters": [
+                 {
+                     "parameterName": "OpusName",
+                     "parameterValue": "Microsoft"
+                 },
+                 {
+                     "parameterName": "OpusInfo",
+                     "parameterValue": "http://www.microsoft.com"
+                 },
+                 {
+                     "parameterName": "FileDigest",
+                     "parameterValue": "/fd \"SHA256\""
+                 },
+                 {
+                     "parameterName": "PageHash",
+                     "parameterValue": "/NPH"
+                 },
+                 {
+                     "parameterName": "TimeStamp",
+                     "parameterValue": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+                 }
+             ],
+             "toolName": "sign",
+             "toolVersion": "1.0"
+         },
+         {
+             "keyCode": "CP-230012",
+             "operationSetCode": "SigntoolVerify",
+             "parameters": [],
+             "toolName": "sign",
+             "toolVersion": "1.0"
+         }
+     ]
+    SessionTimeout: 20
+
+- task: DotNetCoreCLI@2
+  displayName: 'dotnet pack (no build, create NuGet)'
+  inputs:
+    command: pack
+    packagesToPack: '**\Microsoft.Graph.Beta.csproj'
+    nobuild: true
+    includesymbols: true
+
+- task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+  displayName: 'ESRP NuGet CodeSigning'
+  inputs:
+    ConnectedServiceName: 'microsoftgraph ESRP CodeSign DLL and NuGet (AKV)'
+    FolderPath: '$(Build.ArtifactStagingDirectory)'
+    Pattern: '*.nupkg'
+    signConfigType: inlineSignParams
+    inlineOperation: |
+          [
+              {
+                  "keyCode": "CP-401405",
+                  "operationSetCode": "NuGetSign",
+                  "parameters": [ ],
+                  "toolName": "sign",
+                  "toolVersion": "1.0"
+              },
+              {
+                  "keyCode": "CP-401405",
+                  "operationSetCode": "NuGetVerify",
+                  "parameters": [ ],
+                  "toolName": "sign",
+                  "toolVersion": "1.0"
+              }
+          ]
+
+    SessionTimeout: 20
+
+- task: CopyFiles@2
+  displayName: 'Copy release scripts to artifact staging directory'
+  inputs:
+    SourceFolder: '$(Build.SourcesDirectory)'
+    Contents: 'scripts\**'
+    TargetFolder: '$(Build.ArtifactStagingDirectory) '
+
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish Artifact: Microsoft.Graph.Beta.nupkg and release pipeline scripts'
+
+#Task group has not been exported, task groups are not supported yet
+

--- a/pipelines/ci-build.yml
+++ b/pipelines/ci-build.yml
@@ -165,7 +165,7 @@ steps:
     command: pack
     packagesToPack: '**\Microsoft.Graph.Beta.csproj'
     nobuild: true
-    arguments: '-p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg'
+    includesymbols: true
 
 - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
   displayName: 'ESRP NuGet CodeSigning'

--- a/src/Microsoft.Graph/Microsoft.Graph.Beta.csproj
+++ b/src/Microsoft.Graph/Microsoft.Graph.Beta.csproj
@@ -23,7 +23,7 @@
 - Add source link to the nuget package.
     </PackageReleaseNotes>
     <!-- edit this value to change the current major.minor.patch version -->
-    <VersionPrefix>0.40.1</VersionPrefix>
+    <VersionPrefix>0.40.2</VersionPrefix>
     <!-- adds a version suffix if the Prerelease environment variable is set. BUILD_BUILDID is an
     environment variable set by Azure pipelines from the build. We can use the buildid to correlate
     which commit was used to generate the preview build. -->

--- a/src/Microsoft.Graph/Microsoft.Graph.Beta.csproj
+++ b/src/Microsoft.Graph/Microsoft.Graph.Beta.csproj
@@ -23,7 +23,7 @@
 - Add source link to the nuget package.
     </PackageReleaseNotes>
     <!-- edit this value to change the current major.minor.patch version -->
-    <VersionPrefix>0.40.0</VersionPrefix>
+    <VersionPrefix>0.40.1</VersionPrefix>
     <!-- adds a version suffix if the Prerelease environment variable is set. BUILD_BUILDID is an
     environment variable set by Azure pipelines from the build. We can use the buildid to correlate
     which commit was used to generate the preview build. -->

--- a/src/Microsoft.Graph/Microsoft.Graph.Beta.csproj
+++ b/src/Microsoft.Graph/Microsoft.Graph.Beta.csproj
@@ -20,10 +20,10 @@
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <PackageReleaseNotes>
-- Add source link to the nuget package.
+- snupkg as symbol file.
     </PackageReleaseNotes>
     <!-- edit this value to change the current major.minor.patch version -->
-    <VersionPrefix>0.40.2</VersionPrefix>
+    <VersionPrefix>0.40.3</VersionPrefix>
     <!-- adds a version suffix if the Prerelease environment variable is set. BUILD_BUILDID is an
     environment variable set by Azure pipelines from the build. We can use the buildid to correlate
     which commit was used to generate the preview build. -->

--- a/src/Microsoft.Graph/Microsoft.Graph.Beta.csproj
+++ b/src/Microsoft.Graph/Microsoft.Graph.Beta.csproj
@@ -20,7 +20,7 @@
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <PackageReleaseNotes>
-- snupkg as symbol file.
+- Uses snupkg as symbol file.
     </PackageReleaseNotes>
     <!-- edit this value to change the current major.minor.patch version -->
     <VersionPrefix>0.40.3</VersionPrefix>


### PR DESCRIPTION
Fixes #250

YAML is auto generated from the original build definition from the old project (0365 Sandbox). My main focus with this PR is to allow publishing of the symbols. We can consider moving the runner into Linux and refactoring the YAML, but I leave that to a further iteration.

The step that is modified is the powershell step that calls `dotnet pack`. Default `dotnet pack` task from Azure DevOps doesn't allow building snupkg files, so I had to introduce a manual `dotnet` call.

Release 0.40.3-preview contains the same code as 0.40.0-preview, except that it allows debugging with SourceLink and symbols. The couple of other patch upgrades, which are included in the commit history, were attempts to get the right symbol package work with the Azure DevOps release pipelines. They were signed off by @MIchaelMainer offline.

For context, release definition is not using YAML so it doesn't appear here. The only extra requirement compared to the older release definition is that it requires NuGet v5.x to be installed prior to `nuget push` so that it can upload `.snupkg` files.

I have tested 0.40.3-preview with debugger and SourceLink and VS was able to download the corresponding files and allowed debugging.