### PR TITLE
Suboptimal fix to append "content" segment to the report URL after th…

### DIFF
--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetM365AppUserDetailRequestBuilder.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetM365AppUserDetailRequestBuilder.cs
@@ -51,6 +51,18 @@ namespace Microsoft.Graph
         }
 
         /// <summary>
+        /// Constructs a new <see cref="ReportRootGetM365AppUserDetailRequestBuilder"/>. Only used internally.
+        /// </summary>
+        /// <param name="requestUrl">The URL for the request.</param>
+        /// <param name="client">The <see cref="IBaseClient"/> for handling requests.</param>
+        public ReportRootGetM365AppUserDetailRequestBuilder(
+            string requestUrl,
+            IBaseClient client)
+            : base(requestUrl, client)
+        {
+        }
+		
+		/// <summary>
         /// A method used by the base class to construct a request class instance.
         /// </summary>
         /// <param name="functionUrl">The request URL to </param>

--- a/src/Microsoft.Graph/Generated/requests/ReportRootRequestBuilder.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootRequestBuilder.cs
@@ -556,10 +556,14 @@ namespace Microsoft.Graph
         public IReportRootGetM365AppUserDetailRequestBuilder GetM365AppUserDetail(
             Date date)
         {
-            return new ReportRootGetM365AppUserDetailRequestBuilder(
+            var baseBuilder = new ReportRootGetM365AppUserDetailRequestBuilder(
                 this.AppendSegmentToRequestUrl("microsoft.graph.getM365AppUserDetail"),
                 this.Client,
                 date);
+
+            return new ReportRootGetM365AppUserDetailRequestBuilder(
+                        baseBuilder.AppendSegmentToRequestUrl("content"),
+                        this.Client);
         }
 
         /// <summary>
@@ -569,10 +573,14 @@ namespace Microsoft.Graph
         public IReportRootGetM365AppUserDetailRequestBuilder GetM365AppUserDetail(
             string period)
         {
-            return new ReportRootGetM365AppUserDetailRequestBuilder(
+            var baseBuilder =  new ReportRootGetM365AppUserDetailRequestBuilder(
                 this.AppendSegmentToRequestUrl("microsoft.graph.getM365AppUserDetail"),
                 this.Client,
                 period);
+
+            return new ReportRootGetM365AppUserDetailRequestBuilder(
+                        baseBuilder.AppendSegmentToRequestUrl("content"),
+                        this.Client);           
         }
 
         /// <summary>

--- a/tests/Microsoft.Graph.DotnetCore.Test/Requests/Generated/ReportRequestTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Test/Requests/Generated/ReportRequestTests.cs
@@ -1,0 +1,39 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+using Microsoft.Graph;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Graph.DotnetCore.Test.Requests.Generated
+{
+    public class ReportRequestTests : RequestTestBase
+    {
+        /// <summary>
+        /// Tests building a request for a report.
+        /// </summary>
+        [Fact]
+        public void BuildReportRequest()
+        {
+            var expectedRequestUri = new Uri(string.Format(Constants.Url.GraphBaseUrlFormatString, "beta") + "/reports/microsoft.graph.getM365AppUserDetail(period='D7')/content");
+            var m365AppUserDetailRequestBuilder = this.graphServiceClient.Reports.GetM365AppUserDetail("D7") as ReportRootGetM365AppUserDetailRequestBuilder;
+
+            Assert.NotNull(m365AppUserDetailRequestBuilder);
+            Assert.Equal(expectedRequestUri, new Uri(m365AppUserDetailRequestBuilder.RequestUrl));
+
+            var m365AppUserDetailReferenceRequest = m365AppUserDetailRequestBuilder.Request() as ReportRootGetM365AppUserDetailRequest;
+            Assert.NotNull(m365AppUserDetailReferenceRequest);
+            Assert.Equal(expectedRequestUri, new Uri(m365AppUserDetailReferenceRequest.RequestUrl));
+        }
+
+ 
+    }
+}


### PR DESCRIPTION
The new M365 reports in the beta Graph require adding /content to the end of the URL to request the report CSV URI as described in this documentation: [https://docs.microsoft.com/en-us/graph/api/reportroot-getm365appuserdetail?view=graph-rest-beta&tabs=http#request](https://docs.microsoft.com/en-us/graph/api/reportroot-getm365appuserdetail?view=graph-rest-beta&tabs=http#request)

This fix appends the /content to the URL in a rather clumsy manner due to the BaseRequestBuilder.RequestURL being an internal, read-only property.