### PR TITLE
Update Abstract types with a base type to use DerivedType Converter

### DIFF
--- a/src/Microsoft.Graph/Generated/ediscovery/model/DataSource.cs
+++ b/src/Microsoft.Graph/Generated/ediscovery/model/DataSource.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph.Ediscovery
     /// <summary>
     /// The type Data Source.
     /// </summary>
+    [JsonConverter(typeof(Microsoft.Graph.DerivedTypeConverter<DataSource>))]
     public partial class DataSource : Microsoft.Graph.Entity
     {
     

--- a/src/Microsoft.Graph/Generated/ediscovery/model/DataSourceContainer.cs
+++ b/src/Microsoft.Graph/Generated/ediscovery/model/DataSourceContainer.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph.Ediscovery
     /// <summary>
     /// The type Data Source Container.
     /// </summary>
+    [JsonConverter(typeof(Microsoft.Graph.DerivedTypeConverter<DataSourceContainer>))]
     public partial class DataSourceContainer : Microsoft.Graph.Entity
     {
     

--- a/src/Microsoft.Graph/Generated/model/ActivityStatistics.cs
+++ b/src/Microsoft.Graph/Generated/model/ActivityStatistics.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Activity Statistics.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<ActivityStatistics>))]
     public partial class ActivityStatistics : Entity
     {
     

--- a/src/Microsoft.Graph/Generated/model/AndroidCertificateProfileBase.cs
+++ b/src/Microsoft.Graph/Generated/model/AndroidCertificateProfileBase.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Android Certificate Profile Base.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<AndroidCertificateProfileBase>))]
     public partial class AndroidCertificateProfileBase : DeviceConfiguration
     {
     

--- a/src/Microsoft.Graph/Generated/model/AndroidDeviceComplianceLocalActionBase.cs
+++ b/src/Microsoft.Graph/Generated/model/AndroidDeviceComplianceLocalActionBase.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Android Device Compliance Local Action Base.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<AndroidDeviceComplianceLocalActionBase>))]
     public partial class AndroidDeviceComplianceLocalActionBase : Entity
     {
     

--- a/src/Microsoft.Graph/Generated/model/AndroidDeviceOwnerCertificateProfileBase.cs
+++ b/src/Microsoft.Graph/Generated/model/AndroidDeviceOwnerCertificateProfileBase.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Android Device Owner Certificate Profile Base.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<AndroidDeviceOwnerCertificateProfileBase>))]
     public partial class AndroidDeviceOwnerCertificateProfileBase : DeviceConfiguration
     {
     

--- a/src/Microsoft.Graph/Generated/model/AndroidDeviceOwnerKioskModeFolderItem.cs
+++ b/src/Microsoft.Graph/Generated/model/AndroidDeviceOwnerKioskModeFolderItem.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type AndroidDeviceOwnerKioskModeFolderItem.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<AndroidDeviceOwnerKioskModeFolderItem>))]
     public abstract partial class AndroidDeviceOwnerKioskModeFolderItem : AndroidDeviceOwnerKioskModeHomeScreenItem
     {
 

--- a/src/Microsoft.Graph/Generated/model/AndroidForWorkCertificateProfileBase.cs
+++ b/src/Microsoft.Graph/Generated/model/AndroidForWorkCertificateProfileBase.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Android For Work Certificate Profile Base.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<AndroidForWorkCertificateProfileBase>))]
     public partial class AndroidForWorkCertificateProfileBase : DeviceConfiguration
     {
     

--- a/src/Microsoft.Graph/Generated/model/AndroidForWorkEasEmailProfileBase.cs
+++ b/src/Microsoft.Graph/Generated/model/AndroidForWorkEasEmailProfileBase.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Android For Work Eas Email Profile Base.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<AndroidForWorkEasEmailProfileBase>))]
     public partial class AndroidForWorkEasEmailProfileBase : DeviceConfiguration
     {
     

--- a/src/Microsoft.Graph/Generated/model/AndroidWorkProfileCertificateProfileBase.cs
+++ b/src/Microsoft.Graph/Generated/model/AndroidWorkProfileCertificateProfileBase.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Android Work Profile Certificate Profile Base.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<AndroidWorkProfileCertificateProfileBase>))]
     public partial class AndroidWorkProfileCertificateProfileBase : DeviceConfiguration
     {
     

--- a/src/Microsoft.Graph/Generated/model/AndroidWorkProfileEasEmailProfileBase.cs
+++ b/src/Microsoft.Graph/Generated/model/AndroidWorkProfileEasEmailProfileBase.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Android Work Profile Eas Email Profile Base.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<AndroidWorkProfileEasEmailProfileBase>))]
     public partial class AndroidWorkProfileEasEmailProfileBase : DeviceConfiguration
     {
     

--- a/src/Microsoft.Graph/Generated/model/AppleDeviceFeaturesConfigurationBase.cs
+++ b/src/Microsoft.Graph/Generated/model/AppleDeviceFeaturesConfigurationBase.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Apple Device Features Configuration Base.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<AppleDeviceFeaturesConfigurationBase>))]
     public partial class AppleDeviceFeaturesConfigurationBase : DeviceConfiguration
     {
     

--- a/src/Microsoft.Graph/Generated/model/AppleExpeditedCheckinConfigurationBase.cs
+++ b/src/Microsoft.Graph/Generated/model/AppleExpeditedCheckinConfigurationBase.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Apple Expedited Checkin Configuration Base.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<AppleExpeditedCheckinConfigurationBase>))]
     public partial class AppleExpeditedCheckinConfigurationBase : DeviceConfiguration
     {
     

--- a/src/Microsoft.Graph/Generated/model/AppleVpnConfiguration.cs
+++ b/src/Microsoft.Graph/Generated/model/AppleVpnConfiguration.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Apple Vpn Configuration.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<AppleVpnConfiguration>))]
     public partial class AppleVpnConfiguration : DeviceConfiguration
     {
     

--- a/src/Microsoft.Graph/Generated/model/Attachment.cs
+++ b/src/Microsoft.Graph/Generated/model/Attachment.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Attachment.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<Attachment>))]
     public partial class Attachment : Entity
     {
     

--- a/src/Microsoft.Graph/Generated/model/AuthenticationMethod.cs
+++ b/src/Microsoft.Graph/Generated/model/AuthenticationMethod.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Authentication Method.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<AuthenticationMethod>))]
     public partial class AuthenticationMethod : Entity
     {
     

--- a/src/Microsoft.Graph/Generated/model/AuthenticationMethodConfiguration.cs
+++ b/src/Microsoft.Graph/Generated/model/AuthenticationMethodConfiguration.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Authentication Method Configuration.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<AuthenticationMethodConfiguration>))]
     public partial class AuthenticationMethodConfiguration : Entity
     {
     

--- a/src/Microsoft.Graph/Generated/model/BaseItem.cs
+++ b/src/Microsoft.Graph/Generated/model/BaseItem.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Base Item.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<BaseItem>))]
     public partial class BaseItem : Entity
     {
     

--- a/src/Microsoft.Graph/Generated/model/BaseItemVersion.cs
+++ b/src/Microsoft.Graph/Generated/model/BaseItemVersion.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Base Item Version.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<BaseItemVersion>))]
     public partial class BaseItemVersion : Entity
     {
     

--- a/src/Microsoft.Graph/Generated/model/BookingNamedEntity.cs
+++ b/src/Microsoft.Graph/Generated/model/BookingNamedEntity.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Booking Named Entity.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<BookingNamedEntity>))]
     public partial class BookingNamedEntity : Entity
     {
     

--- a/src/Microsoft.Graph/Generated/model/ChangeTrackedEntity.cs
+++ b/src/Microsoft.Graph/Generated/model/ChangeTrackedEntity.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Change Tracked Entity.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<ChangeTrackedEntity>))]
     public partial class ChangeTrackedEntity : Entity
     {
     

--- a/src/Microsoft.Graph/Generated/model/ConversationMember.cs
+++ b/src/Microsoft.Graph/Generated/model/ConversationMember.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Conversation Member.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<ConversationMember>))]
     public partial class ConversationMember : Entity
     {
     

--- a/src/Microsoft.Graph/Generated/model/DepEnrollmentBaseProfile.cs
+++ b/src/Microsoft.Graph/Generated/model/DepEnrollmentBaseProfile.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Dep Enrollment Base Profile.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<DepEnrollmentBaseProfile>))]
     public partial class DepEnrollmentBaseProfile : EnrollmentProfile
     {
     

--- a/src/Microsoft.Graph/Generated/model/DeviceCompliancePolicy.cs
+++ b/src/Microsoft.Graph/Generated/model/DeviceCompliancePolicy.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Device Compliance Policy.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<DeviceCompliancePolicy>))]
     public partial class DeviceCompliancePolicy : Entity
     {
     

--- a/src/Microsoft.Graph/Generated/model/DeviceConfiguration.cs
+++ b/src/Microsoft.Graph/Generated/model/DeviceConfiguration.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Device Configuration.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<DeviceConfiguration>))]
     public partial class DeviceConfiguration : Entity
     {
     

--- a/src/Microsoft.Graph/Generated/model/DeviceEnrollmentConfiguration.cs
+++ b/src/Microsoft.Graph/Generated/model/DeviceEnrollmentConfiguration.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Device Enrollment Configuration.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<DeviceEnrollmentConfiguration>))]
     public partial class DeviceEnrollmentConfiguration : Entity
     {
     

--- a/src/Microsoft.Graph/Generated/model/DeviceHealthScriptTimeSchedule.cs
+++ b/src/Microsoft.Graph/Generated/model/DeviceHealthScriptTimeSchedule.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type DeviceHealthScriptTimeSchedule.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<DeviceHealthScriptTimeSchedule>))]
     public abstract partial class DeviceHealthScriptTimeSchedule : DeviceHealthScriptRunSchedule
     {
 

--- a/src/Microsoft.Graph/Generated/model/DeviceManagementConfigurationSimpleSettingValue.cs
+++ b/src/Microsoft.Graph/Generated/model/DeviceManagementConfigurationSimpleSettingValue.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type DeviceManagementConfigurationSimpleSettingValue.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<DeviceManagementConfigurationSimpleSettingValue>))]
     public abstract partial class DeviceManagementConfigurationSimpleSettingValue : DeviceManagementConfigurationSettingValue
     {
 

--- a/src/Microsoft.Graph/Generated/model/DeviceManagementResourceAccessProfileBase.cs
+++ b/src/Microsoft.Graph/Generated/model/DeviceManagementResourceAccessProfileBase.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Device Management Resource Access Profile Base.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<DeviceManagementResourceAccessProfileBase>))]
     public partial class DeviceManagementResourceAccessProfileBase : Entity
     {
     

--- a/src/Microsoft.Graph/Generated/model/DeviceManagementSettingInstance.cs
+++ b/src/Microsoft.Graph/Generated/model/DeviceManagementSettingInstance.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Device Management Setting Instance.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<DeviceManagementSettingInstance>))]
     public partial class DeviceManagementSettingInstance : Entity
     {
     

--- a/src/Microsoft.Graph/Generated/model/DeviceSetupConfiguration.cs
+++ b/src/Microsoft.Graph/Generated/model/DeviceSetupConfiguration.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Device Setup Configuration.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<DeviceSetupConfiguration>))]
     public partial class DeviceSetupConfiguration : Entity
     {
     

--- a/src/Microsoft.Graph/Generated/model/EasEmailProfileConfigurationBase.cs
+++ b/src/Microsoft.Graph/Generated/model/EasEmailProfileConfigurationBase.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Eas Email Profile Configuration Base.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<EasEmailProfileConfigurationBase>))]
     public partial class EasEmailProfileConfigurationBase : DeviceConfiguration
     {
     

--- a/src/Microsoft.Graph/Generated/model/EducationOrganization.cs
+++ b/src/Microsoft.Graph/Generated/model/EducationOrganization.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Education Organization.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<EducationOrganization>))]
     public partial class EducationOrganization : Entity
     {
     

--- a/src/Microsoft.Graph/Generated/model/EducationOutcome.cs
+++ b/src/Microsoft.Graph/Generated/model/EducationOutcome.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Education Outcome.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<EducationOutcome>))]
     public partial class EducationOutcome : Entity
     {
     

--- a/src/Microsoft.Graph/Generated/model/EncryptContent.cs
+++ b/src/Microsoft.Graph/Generated/model/EncryptContent.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type EncryptContent.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<EncryptContent>))]
     public abstract partial class EncryptContent : LabelActionBase
     {
 

--- a/src/Microsoft.Graph/Generated/model/ExactMatchJobBase.cs
+++ b/src/Microsoft.Graph/Generated/model/ExactMatchJobBase.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Exact Match Job Base.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<ExactMatchJobBase>))]
     public partial class ExactMatchJobBase : Entity
     {
     

--- a/src/Microsoft.Graph/Generated/model/Extension.cs
+++ b/src/Microsoft.Graph/Generated/model/Extension.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Extension.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<Extension>))]
     public partial class Extension : Entity
     {
     

--- a/src/Microsoft.Graph/Generated/model/IosCertificateProfile.cs
+++ b/src/Microsoft.Graph/Generated/model/IosCertificateProfile.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Ios Certificate Profile.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<IosCertificateProfile>))]
     public partial class IosCertificateProfile : DeviceConfiguration
     {
     

--- a/src/Microsoft.Graph/Generated/model/IosCertificateProfileBase.cs
+++ b/src/Microsoft.Graph/Generated/model/IosCertificateProfileBase.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Ios Certificate Profile Base.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<IosCertificateProfileBase>))]
     public partial class IosCertificateProfileBase : IosCertificateProfile
     {
     

--- a/src/Microsoft.Graph/Generated/model/IosSingleSignOnExtension.cs
+++ b/src/Microsoft.Graph/Generated/model/IosSingleSignOnExtension.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type IosSingleSignOnExtension.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<IosSingleSignOnExtension>))]
     public abstract partial class IosSingleSignOnExtension : SingleSignOnExtension
     {
 

--- a/src/Microsoft.Graph/Generated/model/ItemFacet.cs
+++ b/src/Microsoft.Graph/Generated/model/ItemFacet.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Item Facet.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<ItemFacet>))]
     public partial class ItemFacet : Entity
     {
     

--- a/src/Microsoft.Graph/Generated/model/KerberosSingleSignOnExtension.cs
+++ b/src/Microsoft.Graph/Generated/model/KerberosSingleSignOnExtension.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type KerberosSingleSignOnExtension.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<KerberosSingleSignOnExtension>))]
     public abstract partial class KerberosSingleSignOnExtension : SingleSignOnExtension
     {
 

--- a/src/Microsoft.Graph/Generated/model/LocationManagementCondition.cs
+++ b/src/Microsoft.Graph/Generated/model/LocationManagementCondition.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Location Management Condition.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<LocationManagementCondition>))]
     public partial class LocationManagementCondition : ManagementCondition
     {
     

--- a/src/Microsoft.Graph/Generated/model/MacOSCertificateProfileBase.cs
+++ b/src/Microsoft.Graph/Generated/model/MacOSCertificateProfileBase.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Mac OSCertificate Profile Base.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<MacOSCertificateProfileBase>))]
     public partial class MacOSCertificateProfileBase : DeviceConfiguration
     {
     

--- a/src/Microsoft.Graph/Generated/model/MacOSSingleSignOnExtension.cs
+++ b/src/Microsoft.Graph/Generated/model/MacOSSingleSignOnExtension.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type MacOSSingleSignOnExtension.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<MacOSSingleSignOnExtension>))]
     public abstract partial class MacOSSingleSignOnExtension : SingleSignOnExtension
     {
 

--- a/src/Microsoft.Graph/Generated/model/ManagedApp.cs
+++ b/src/Microsoft.Graph/Generated/model/ManagedApp.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Managed App.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<ManagedApp>))]
     public partial class ManagedApp : MobileApp
     {
     

--- a/src/Microsoft.Graph/Generated/model/ManagedAppConfiguration.cs
+++ b/src/Microsoft.Graph/Generated/model/ManagedAppConfiguration.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Managed App Configuration.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<ManagedAppConfiguration>))]
     public partial class ManagedAppConfiguration : ManagedAppPolicy
     {
     

--- a/src/Microsoft.Graph/Generated/model/ManagedAppPolicy.cs
+++ b/src/Microsoft.Graph/Generated/model/ManagedAppPolicy.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Managed App Policy.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<ManagedAppPolicy>))]
     public partial class ManagedAppPolicy : Entity
     {
     

--- a/src/Microsoft.Graph/Generated/model/ManagedAppProtection.cs
+++ b/src/Microsoft.Graph/Generated/model/ManagedAppProtection.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Managed App Protection.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<ManagedAppProtection>))]
     public partial class ManagedAppProtection : ManagedAppPolicy
     {
     

--- a/src/Microsoft.Graph/Generated/model/ManagedAppRegistration.cs
+++ b/src/Microsoft.Graph/Generated/model/ManagedAppRegistration.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Managed App Registration.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<ManagedAppRegistration>))]
     public partial class ManagedAppRegistration : Entity
     {
     

--- a/src/Microsoft.Graph/Generated/model/ManagedAppStatus.cs
+++ b/src/Microsoft.Graph/Generated/model/ManagedAppStatus.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Managed App Status.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<ManagedAppStatus>))]
     public partial class ManagedAppStatus : Entity
     {
     

--- a/src/Microsoft.Graph/Generated/model/ManagedDeviceMobileAppConfiguration.cs
+++ b/src/Microsoft.Graph/Generated/model/ManagedDeviceMobileAppConfiguration.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Managed Device Mobile App Configuration.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<ManagedDeviceMobileAppConfiguration>))]
     public partial class ManagedDeviceMobileAppConfiguration : Entity
     {
     

--- a/src/Microsoft.Graph/Generated/model/ManagedEBook.cs
+++ b/src/Microsoft.Graph/Generated/model/ManagedEBook.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Managed EBook.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<ManagedEBook>))]
     public partial class ManagedEBook : Entity
     {
     

--- a/src/Microsoft.Graph/Generated/model/ManagedMobileLobApp.cs
+++ b/src/Microsoft.Graph/Generated/model/ManagedMobileLobApp.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Managed Mobile Lob App.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<ManagedMobileLobApp>))]
     public partial class ManagedMobileLobApp : ManagedApp
     {
     

--- a/src/Microsoft.Graph/Generated/model/ManagementCondition.cs
+++ b/src/Microsoft.Graph/Generated/model/ManagementCondition.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Management Condition.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<ManagementCondition>))]
     public partial class ManagementCondition : Entity
     {
     

--- a/src/Microsoft.Graph/Generated/model/ManagementConditionExpressionModel.cs
+++ b/src/Microsoft.Graph/Generated/model/ManagementConditionExpressionModel.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type ManagementConditionExpressionModel.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<ManagementConditionExpressionModel>))]
     public abstract partial class ManagementConditionExpressionModel : ManagementConditionExpression
     {
 

--- a/src/Microsoft.Graph/Generated/model/MarkContent.cs
+++ b/src/Microsoft.Graph/Generated/model/MarkContent.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type MarkContent.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<MarkContent>))]
     public abstract partial class MarkContent : LabelActionBase
     {
 

--- a/src/Microsoft.Graph/Generated/model/MobileApp.cs
+++ b/src/Microsoft.Graph/Generated/model/MobileApp.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Mobile App.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<MobileApp>))]
     public partial class MobileApp : Entity
     {
     

--- a/src/Microsoft.Graph/Generated/model/MobileAppRelationship.cs
+++ b/src/Microsoft.Graph/Generated/model/MobileAppRelationship.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Mobile App Relationship.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<MobileAppRelationship>))]
     public partial class MobileAppRelationship : Entity
     {
     

--- a/src/Microsoft.Graph/Generated/model/MobileContainedApp.cs
+++ b/src/Microsoft.Graph/Generated/model/MobileContainedApp.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Mobile Contained App.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<MobileContainedApp>))]
     public partial class MobileContainedApp : Entity
     {
     

--- a/src/Microsoft.Graph/Generated/model/MobileLobApp.cs
+++ b/src/Microsoft.Graph/Generated/model/MobileLobApp.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Mobile Lob App.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<MobileLobApp>))]
     public partial class MobileLobApp : MobileApp
     {
     

--- a/src/Microsoft.Graph/Generated/model/NetworkManagementCondition.cs
+++ b/src/Microsoft.Graph/Generated/model/NetworkManagementCondition.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Network Management Condition.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<NetworkManagementCondition>))]
     public partial class NetworkManagementCondition : ManagementCondition
     {
     

--- a/src/Microsoft.Graph/Generated/model/OfficeClientConfiguration.cs
+++ b/src/Microsoft.Graph/Generated/model/OfficeClientConfiguration.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Office Client Configuration.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<OfficeClientConfiguration>))]
     public partial class OfficeClientConfiguration : Entity
     {
     

--- a/src/Microsoft.Graph/Generated/model/OnenoteEntityBaseModel.cs
+++ b/src/Microsoft.Graph/Generated/model/OnenoteEntityBaseModel.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Onenote Entity Base Model.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<OnenoteEntityBaseModel>))]
     public partial class OnenoteEntityBaseModel : Entity
     {
     

--- a/src/Microsoft.Graph/Generated/model/OnenoteEntityHierarchyModel.cs
+++ b/src/Microsoft.Graph/Generated/model/OnenoteEntityHierarchyModel.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Onenote Entity Hierarchy Model.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<OnenoteEntityHierarchyModel>))]
     public partial class OnenoteEntityHierarchyModel : OnenoteEntitySchemaObjectModel
     {
     

--- a/src/Microsoft.Graph/Generated/model/OnenoteEntitySchemaObjectModel.cs
+++ b/src/Microsoft.Graph/Generated/model/OnenoteEntitySchemaObjectModel.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Onenote Entity Schema Object Model.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<OnenoteEntitySchemaObjectModel>))]
     public partial class OnenoteEntitySchemaObjectModel : OnenoteEntityBaseModel
     {
     

--- a/src/Microsoft.Graph/Generated/model/OpenShiftChangeRequest.cs
+++ b/src/Microsoft.Graph/Generated/model/OpenShiftChangeRequest.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Open Shift Change Request.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<OpenShiftChangeRequestObject>))]
     public partial class OpenShiftChangeRequestObject : ScheduleChangeRequestObject
     {
     

--- a/src/Microsoft.Graph/Generated/model/OrganizationalBrandingProperties.cs
+++ b/src/Microsoft.Graph/Generated/model/OrganizationalBrandingProperties.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Organizational Branding Properties.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<OrganizationalBrandingProperties>))]
     public partial class OrganizationalBrandingProperties : Entity
     {
     

--- a/src/Microsoft.Graph/Generated/model/OutlookItem.cs
+++ b/src/Microsoft.Graph/Generated/model/OutlookItem.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Outlook Item.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<OutlookItem>))]
     public partial class OutlookItem : Entity
     {
     

--- a/src/Microsoft.Graph/Generated/model/Place.cs
+++ b/src/Microsoft.Graph/Generated/model/Place.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Place.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<Place>))]
     public partial class Place : Entity
     {
     

--- a/src/Microsoft.Graph/Generated/model/PolicyBase.cs
+++ b/src/Microsoft.Graph/Generated/model/PolicyBase.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Policy Base.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<PolicyBase>))]
     public partial class PolicyBase : DirectoryObject
     {
     

--- a/src/Microsoft.Graph/Generated/model/PolicySetItem.cs
+++ b/src/Microsoft.Graph/Generated/model/PolicySetItem.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Policy Set Item.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<PolicySetItem>))]
     public partial class PolicySetItem : Entity
     {
     

--- a/src/Microsoft.Graph/Generated/model/PrintOperation.cs
+++ b/src/Microsoft.Graph/Generated/model/PrintOperation.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Print Operation.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<PrintOperation>))]
     public partial class PrintOperation : Entity
     {
     

--- a/src/Microsoft.Graph/Generated/model/PrintUsage.cs
+++ b/src/Microsoft.Graph/Generated/model/PrintUsage.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Print Usage.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<PrintUsage>))]
     public partial class PrintUsage : Entity
     {
     

--- a/src/Microsoft.Graph/Generated/model/PrinterBase.cs
+++ b/src/Microsoft.Graph/Generated/model/PrinterBase.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Printer Base.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<PrinterBase>))]
     public partial class PrinterBase : Entity
     {
     

--- a/src/Microsoft.Graph/Generated/model/ScheduleChangeRequest.cs
+++ b/src/Microsoft.Graph/Generated/model/ScheduleChangeRequest.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Schedule Change Request.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<ScheduleChangeRequestObject>))]
     public partial class ScheduleChangeRequestObject : ChangeTrackedEntity
     {
     

--- a/src/Microsoft.Graph/Generated/model/StsPolicy.cs
+++ b/src/Microsoft.Graph/Generated/model/StsPolicy.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Sts Policy.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<StsPolicy>))]
     public partial class StsPolicy : PolicyBase
     {
     

--- a/src/Microsoft.Graph/Generated/model/TargetedManagedAppProtection.cs
+++ b/src/Microsoft.Graph/Generated/model/TargetedManagedAppProtection.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Targeted Managed App Protection.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<TargetedManagedAppProtection>))]
     public partial class TargetedManagedAppProtection : ManagedAppProtection
     {
     

--- a/src/Microsoft.Graph/Generated/model/ThreatAssessmentRequest.cs
+++ b/src/Microsoft.Graph/Generated/model/ThreatAssessmentRequest.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Threat Assessment Request.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<ThreatAssessmentRequestObject>))]
     public partial class ThreatAssessmentRequestObject : Entity
     {
     

--- a/src/Microsoft.Graph/Generated/model/UnifiedRoleManagementPolicyRule.cs
+++ b/src/Microsoft.Graph/Generated/model/UnifiedRoleManagementPolicyRule.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Unified Role Management Policy Rule.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<UnifiedRoleManagementPolicyRule>))]
     public partial class UnifiedRoleManagementPolicyRule : Entity
     {
     

--- a/src/Microsoft.Graph/Generated/model/VpnConfiguration.cs
+++ b/src/Microsoft.Graph/Generated/model/VpnConfiguration.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Vpn Configuration.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<VpnConfiguration>))]
     public partial class VpnConfiguration : DeviceConfiguration
     {
     

--- a/src/Microsoft.Graph/Generated/model/Windows10CertificateProfileBase.cs
+++ b/src/Microsoft.Graph/Generated/model/Windows10CertificateProfileBase.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Windows10Certificate Profile Base.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<Windows10CertificateProfileBase>))]
     public partial class Windows10CertificateProfileBase : WindowsCertificateProfileBase
     {
     

--- a/src/Microsoft.Graph/Generated/model/Windows10XCertificateProfile.cs
+++ b/src/Microsoft.Graph/Generated/model/Windows10XCertificateProfile.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Windows10XCertificate Profile.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<Windows10XCertificateProfile>))]
     public partial class Windows10XCertificateProfile : DeviceManagementResourceAccessProfileBase
     {
     

--- a/src/Microsoft.Graph/Generated/model/Windows81CertificateProfileBase.cs
+++ b/src/Microsoft.Graph/Generated/model/Windows81CertificateProfileBase.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Windows81Certificate Profile Base.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<Windows81CertificateProfileBase>))]
     public partial class Windows81CertificateProfileBase : WindowsCertificateProfileBase
     {
     

--- a/src/Microsoft.Graph/Generated/model/WindowsAutopilotDeploymentProfile.cs
+++ b/src/Microsoft.Graph/Generated/model/WindowsAutopilotDeploymentProfile.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Windows Autopilot Deployment Profile.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<WindowsAutopilotDeploymentProfile>))]
     public partial class WindowsAutopilotDeploymentProfile : Entity
     {
     

--- a/src/Microsoft.Graph/Generated/model/WindowsCertificateProfileBase.cs
+++ b/src/Microsoft.Graph/Generated/model/WindowsCertificateProfileBase.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Windows Certificate Profile Base.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<WindowsCertificateProfileBase>))]
     public partial class WindowsCertificateProfileBase : DeviceConfiguration
     {
     

--- a/src/Microsoft.Graph/Generated/model/WindowsInformationProtection.cs
+++ b/src/Microsoft.Graph/Generated/model/WindowsInformationProtection.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Windows Information Protection.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<WindowsInformationProtection>))]
     public partial class WindowsInformationProtection : ManagedAppPolicy
     {
     

--- a/src/Microsoft.Graph/Generated/model/WindowsPhone81CertificateProfileBase.cs
+++ b/src/Microsoft.Graph/Generated/model/WindowsPhone81CertificateProfileBase.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Windows Phone81Certificate Profile Base.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<WindowsPhone81CertificateProfileBase>))]
     public partial class WindowsPhone81CertificateProfileBase : DeviceConfiguration
     {
     

--- a/src/Microsoft.Graph/Generated/model/WindowsUpdateCatalogItem.cs
+++ b/src/Microsoft.Graph/Generated/model/WindowsUpdateCatalogItem.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Windows Update Catalog Item.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<WindowsUpdateCatalogItem>))]
     public partial class WindowsUpdateCatalogItem : Entity
     {
     

--- a/src/Microsoft.Graph/Generated/model/WindowsVpnConfiguration.cs
+++ b/src/Microsoft.Graph/Generated/model/WindowsVpnConfiguration.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Windows Vpn Configuration.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<WindowsVpnConfiguration>))]
     public partial class WindowsVpnConfiguration : DeviceConfiguration
     {
     

--- a/src/Microsoft.Graph/Generated/requests/AuthenticationMethodsRootUsersRegisteredByFeatureRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/AuthenticationMethodsRootUsersRegisteredByFeatureRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="userregistrationfeaturesummary">The UserRegistrationFeatureSummary object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<UserRegistrationFeatureSummary> PatchAsync(UserRegistrationFeatureSummary userregistrationfeaturesummary, 
+        public System.Threading.Tasks.Task<UserRegistrationFeatureSummary> PatchAsync(UserRegistrationFeatureSummary userregistrationfeaturesummary,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="userregistrationfeaturesummary">The UserRegistrationFeatureSummary object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<UserRegistrationFeatureSummary> PutAsync(UserRegistrationFeatureSummary userregistrationfeaturesummary, 
+        public System.Threading.Tasks.Task<UserRegistrationFeatureSummary> PutAsync(UserRegistrationFeatureSummary userregistrationfeaturesummary,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/AuthenticationMethodsRootUsersRegisteredByMethodRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/AuthenticationMethodsRootUsersRegisteredByMethodRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="userregistrationmethodsummary">The UserRegistrationMethodSummary object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<UserRegistrationMethodSummary> PatchAsync(UserRegistrationMethodSummary userregistrationmethodsummary, 
+        public System.Threading.Tasks.Task<UserRegistrationMethodSummary> PatchAsync(UserRegistrationMethodSummary userregistrationmethodsummary,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="userregistrationmethodsummary">The UserRegistrationMethodSummary object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<UserRegistrationMethodSummary> PutAsync(UserRegistrationMethodSummary userregistrationmethodsummary, 
+        public System.Threading.Tasks.Task<UserRegistrationMethodSummary> PutAsync(UserRegistrationMethodSummary userregistrationmethodsummary,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootDeviceConfigurationDeviceActivityRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootDeviceConfigurationDeviceActivityRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootDeviceConfigurationUserActivityRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootDeviceConfigurationUserActivityRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetAzureADApplicationSignInSummaryRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetAzureADApplicationSignInSummaryRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="applicationsigninsummary">The ApplicationSignInSummary object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetAzureADApplicationSignInSummaryCollectionPage> PatchAsync(ApplicationSignInSummary applicationsigninsummary, 
+        public async System.Threading.Tasks.Task<IReportRootGetAzureADApplicationSignInSummaryCollectionPage> PatchAsync(ApplicationSignInSummary applicationsigninsummary,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="applicationsigninsummary">The ApplicationSignInSummary object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetAzureADApplicationSignInSummaryCollectionPage> PutAsync(ApplicationSignInSummary applicationsigninsummary, 
+        public async System.Threading.Tasks.Task<IReportRootGetAzureADApplicationSignInSummaryCollectionPage> PutAsync(ApplicationSignInSummary applicationsigninsummary,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetAzureADFeatureUsageRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetAzureADFeatureUsageRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="azureadfeatureusage">The AzureADFeatureUsage object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetAzureADFeatureUsageCollectionPage> PatchAsync(AzureADFeatureUsage azureadfeatureusage, 
+        public async System.Threading.Tasks.Task<IReportRootGetAzureADFeatureUsageCollectionPage> PatchAsync(AzureADFeatureUsage azureadfeatureusage,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="azureadfeatureusage">The AzureADFeatureUsage object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetAzureADFeatureUsageCollectionPage> PutAsync(AzureADFeatureUsage azureadfeatureusage, 
+        public async System.Threading.Tasks.Task<IReportRootGetAzureADFeatureUsageCollectionPage> PutAsync(AzureADFeatureUsage azureadfeatureusage,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetAzureADLicenseUsageRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetAzureADLicenseUsageRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="azureadlicenseusage">The AzureADLicenseUsage object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetAzureADLicenseUsageCollectionPage> PatchAsync(AzureADLicenseUsage azureadlicenseusage, 
+        public async System.Threading.Tasks.Task<IReportRootGetAzureADLicenseUsageCollectionPage> PatchAsync(AzureADLicenseUsage azureadlicenseusage,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="azureadlicenseusage">The AzureADLicenseUsage object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetAzureADLicenseUsageCollectionPage> PutAsync(AzureADLicenseUsage azureadlicenseusage, 
+        public async System.Threading.Tasks.Task<IReportRootGetAzureADLicenseUsageCollectionPage> PutAsync(AzureADLicenseUsage azureadlicenseusage,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetAzureADUserFeatureUsageRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetAzureADUserFeatureUsageRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="azureaduserfeatureusage">The AzureADUserFeatureUsage object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetAzureADUserFeatureUsageCollectionPage> PatchAsync(AzureADUserFeatureUsage azureaduserfeatureusage, 
+        public async System.Threading.Tasks.Task<IReportRootGetAzureADUserFeatureUsageCollectionPage> PatchAsync(AzureADUserFeatureUsage azureaduserfeatureusage,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="azureaduserfeatureusage">The AzureADUserFeatureUsage object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetAzureADUserFeatureUsageCollectionPage> PutAsync(AzureADUserFeatureUsage azureaduserfeatureusage, 
+        public async System.Threading.Tasks.Task<IReportRootGetAzureADUserFeatureUsageCollectionPage> PutAsync(AzureADUserFeatureUsage azureaduserfeatureusage,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetCredentialUsageSummaryRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetCredentialUsageSummaryRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="credentialusagesummary">The CredentialUsageSummary object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetCredentialUsageSummaryCollectionPage> PatchAsync(CredentialUsageSummary credentialusagesummary, 
+        public async System.Threading.Tasks.Task<IReportRootGetCredentialUsageSummaryCollectionPage> PatchAsync(CredentialUsageSummary credentialusagesummary,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="credentialusagesummary">The CredentialUsageSummary object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetCredentialUsageSummaryCollectionPage> PutAsync(CredentialUsageSummary credentialusagesummary, 
+        public async System.Threading.Tasks.Task<IReportRootGetCredentialUsageSummaryCollectionPage> PutAsync(CredentialUsageSummary credentialusagesummary,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetCredentialUserRegistrationCountRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetCredentialUserRegistrationCountRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="credentialuserregistrationcount">The CredentialUserRegistrationCount object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetCredentialUserRegistrationCountCollectionPage> PatchAsync(CredentialUserRegistrationCount credentialuserregistrationcount, 
+        public async System.Threading.Tasks.Task<IReportRootGetCredentialUserRegistrationCountCollectionPage> PatchAsync(CredentialUserRegistrationCount credentialuserregistrationcount,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="credentialuserregistrationcount">The CredentialUserRegistrationCount object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetCredentialUserRegistrationCountCollectionPage> PutAsync(CredentialUserRegistrationCount credentialuserregistrationcount, 
+        public async System.Threading.Tasks.Task<IReportRootGetCredentialUserRegistrationCountCollectionPage> PutAsync(CredentialUserRegistrationCount credentialuserregistrationcount,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetEmailActivityCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetEmailActivityCountsRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="emailactivitysummary">The EmailActivitySummary object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetEmailActivityCountsCollectionPage> PatchAsync(EmailActivitySummary emailactivitysummary, 
+        public async System.Threading.Tasks.Task<IReportRootGetEmailActivityCountsCollectionPage> PatchAsync(EmailActivitySummary emailactivitysummary,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="emailactivitysummary">The EmailActivitySummary object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetEmailActivityCountsCollectionPage> PutAsync(EmailActivitySummary emailactivitysummary, 
+        public async System.Threading.Tasks.Task<IReportRootGetEmailActivityCountsCollectionPage> PutAsync(EmailActivitySummary emailactivitysummary,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetEmailActivityUserCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetEmailActivityUserCountsRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="emailactivitysummary">The EmailActivitySummary object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetEmailActivityUserCountsCollectionPage> PatchAsync(EmailActivitySummary emailactivitysummary, 
+        public async System.Threading.Tasks.Task<IReportRootGetEmailActivityUserCountsCollectionPage> PatchAsync(EmailActivitySummary emailactivitysummary,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="emailactivitysummary">The EmailActivitySummary object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetEmailActivityUserCountsCollectionPage> PutAsync(EmailActivitySummary emailactivitysummary, 
+        public async System.Threading.Tasks.Task<IReportRootGetEmailActivityUserCountsCollectionPage> PutAsync(EmailActivitySummary emailactivitysummary,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetEmailActivityUserDetailRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetEmailActivityUserDetailRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="emailactivityuserdetail">The EmailActivityUserDetail object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetEmailActivityUserDetailCollectionPage> PatchAsync(EmailActivityUserDetail emailactivityuserdetail, 
+        public async System.Threading.Tasks.Task<IReportRootGetEmailActivityUserDetailCollectionPage> PatchAsync(EmailActivityUserDetail emailactivityuserdetail,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="emailactivityuserdetail">The EmailActivityUserDetail object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetEmailActivityUserDetailCollectionPage> PutAsync(EmailActivityUserDetail emailactivityuserdetail, 
+        public async System.Threading.Tasks.Task<IReportRootGetEmailActivityUserDetailCollectionPage> PutAsync(EmailActivityUserDetail emailactivityuserdetail,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetEmailAppUsageAppsUserCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetEmailAppUsageAppsUserCountsRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="emailappusageappsusercounts">The EmailAppUsageAppsUserCounts object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetEmailAppUsageAppsUserCountsCollectionPage> PatchAsync(EmailAppUsageAppsUserCounts emailappusageappsusercounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetEmailAppUsageAppsUserCountsCollectionPage> PatchAsync(EmailAppUsageAppsUserCounts emailappusageappsusercounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="emailappusageappsusercounts">The EmailAppUsageAppsUserCounts object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetEmailAppUsageAppsUserCountsCollectionPage> PutAsync(EmailAppUsageAppsUserCounts emailappusageappsusercounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetEmailAppUsageAppsUserCountsCollectionPage> PutAsync(EmailAppUsageAppsUserCounts emailappusageappsusercounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetEmailAppUsageUserCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetEmailAppUsageUserCountsRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="emailappusageusercounts">The EmailAppUsageUserCounts object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetEmailAppUsageUserCountsCollectionPage> PatchAsync(EmailAppUsageUserCounts emailappusageusercounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetEmailAppUsageUserCountsCollectionPage> PatchAsync(EmailAppUsageUserCounts emailappusageusercounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="emailappusageusercounts">The EmailAppUsageUserCounts object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetEmailAppUsageUserCountsCollectionPage> PutAsync(EmailAppUsageUserCounts emailappusageusercounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetEmailAppUsageUserCountsCollectionPage> PutAsync(EmailAppUsageUserCounts emailappusageusercounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetEmailAppUsageUserDetailRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetEmailAppUsageUserDetailRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="emailappusageuserdetail">The EmailAppUsageUserDetail object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetEmailAppUsageUserDetailCollectionPage> PatchAsync(EmailAppUsageUserDetail emailappusageuserdetail, 
+        public async System.Threading.Tasks.Task<IReportRootGetEmailAppUsageUserDetailCollectionPage> PatchAsync(EmailAppUsageUserDetail emailappusageuserdetail,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="emailappusageuserdetail">The EmailAppUsageUserDetail object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetEmailAppUsageUserDetailCollectionPage> PutAsync(EmailAppUsageUserDetail emailappusageuserdetail, 
+        public async System.Threading.Tasks.Task<IReportRootGetEmailAppUsageUserDetailCollectionPage> PutAsync(EmailAppUsageUserDetail emailappusageuserdetail,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetEmailAppUsageVersionsUserCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetEmailAppUsageVersionsUserCountsRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="emailappusageversionsusercounts">The EmailAppUsageVersionsUserCounts object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetEmailAppUsageVersionsUserCountsCollectionPage> PatchAsync(EmailAppUsageVersionsUserCounts emailappusageversionsusercounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetEmailAppUsageVersionsUserCountsCollectionPage> PatchAsync(EmailAppUsageVersionsUserCounts emailappusageversionsusercounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="emailappusageversionsusercounts">The EmailAppUsageVersionsUserCounts object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetEmailAppUsageVersionsUserCountsCollectionPage> PutAsync(EmailAppUsageVersionsUserCounts emailappusageversionsusercounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetEmailAppUsageVersionsUserCountsCollectionPage> PutAsync(EmailAppUsageVersionsUserCounts emailappusageversionsusercounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetM365AppPlatformUserCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetM365AppPlatformUserCountsRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetM365AppUserCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetM365AppUserCountsRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetM365AppUserDetailRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetM365AppUserDetailRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetMailboxUsageDetailRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetMailboxUsageDetailRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="mailboxusagedetail">The MailboxUsageDetail object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetMailboxUsageDetailCollectionPage> PatchAsync(MailboxUsageDetail mailboxusagedetail, 
+        public async System.Threading.Tasks.Task<IReportRootGetMailboxUsageDetailCollectionPage> PatchAsync(MailboxUsageDetail mailboxusagedetail,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="mailboxusagedetail">The MailboxUsageDetail object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetMailboxUsageDetailCollectionPage> PutAsync(MailboxUsageDetail mailboxusagedetail, 
+        public async System.Threading.Tasks.Task<IReportRootGetMailboxUsageDetailCollectionPage> PutAsync(MailboxUsageDetail mailboxusagedetail,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetMailboxUsageMailboxCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetMailboxUsageMailboxCountsRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="mailboxusagemailboxcounts">The MailboxUsageMailboxCounts object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetMailboxUsageMailboxCountsCollectionPage> PatchAsync(MailboxUsageMailboxCounts mailboxusagemailboxcounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetMailboxUsageMailboxCountsCollectionPage> PatchAsync(MailboxUsageMailboxCounts mailboxusagemailboxcounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="mailboxusagemailboxcounts">The MailboxUsageMailboxCounts object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetMailboxUsageMailboxCountsCollectionPage> PutAsync(MailboxUsageMailboxCounts mailboxusagemailboxcounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetMailboxUsageMailboxCountsCollectionPage> PutAsync(MailboxUsageMailboxCounts mailboxusagemailboxcounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetMailboxUsageQuotaStatusMailboxCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetMailboxUsageQuotaStatusMailboxCountsRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="mailboxusagequotastatusmailboxcounts">The MailboxUsageQuotaStatusMailboxCounts object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetMailboxUsageQuotaStatusMailboxCountsCollectionPage> PatchAsync(MailboxUsageQuotaStatusMailboxCounts mailboxusagequotastatusmailboxcounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetMailboxUsageQuotaStatusMailboxCountsCollectionPage> PatchAsync(MailboxUsageQuotaStatusMailboxCounts mailboxusagequotastatusmailboxcounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="mailboxusagequotastatusmailboxcounts">The MailboxUsageQuotaStatusMailboxCounts object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetMailboxUsageQuotaStatusMailboxCountsCollectionPage> PutAsync(MailboxUsageQuotaStatusMailboxCounts mailboxusagequotastatusmailboxcounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetMailboxUsageQuotaStatusMailboxCountsCollectionPage> PutAsync(MailboxUsageQuotaStatusMailboxCounts mailboxusagequotastatusmailboxcounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetMailboxUsageStorageRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetMailboxUsageStorageRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="mailboxusagestorage">The MailboxUsageStorage object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetMailboxUsageStorageCollectionPage> PatchAsync(MailboxUsageStorage mailboxusagestorage, 
+        public async System.Threading.Tasks.Task<IReportRootGetMailboxUsageStorageCollectionPage> PatchAsync(MailboxUsageStorage mailboxusagestorage,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="mailboxusagestorage">The MailboxUsageStorage object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetMailboxUsageStorageCollectionPage> PutAsync(MailboxUsageStorage mailboxusagestorage, 
+        public async System.Threading.Tasks.Task<IReportRootGetMailboxUsageStorageCollectionPage> PutAsync(MailboxUsageStorage mailboxusagestorage,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetOffice365ActivationCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetOffice365ActivationCountsRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="office365activationcounts">The Office365ActivationCounts object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetOffice365ActivationCountsCollectionPage> PatchAsync(Office365ActivationCounts office365activationcounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetOffice365ActivationCountsCollectionPage> PatchAsync(Office365ActivationCounts office365activationcounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="office365activationcounts">The Office365ActivationCounts object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetOffice365ActivationCountsCollectionPage> PutAsync(Office365ActivationCounts office365activationcounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetOffice365ActivationCountsCollectionPage> PutAsync(Office365ActivationCounts office365activationcounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetOffice365ActivationsUserCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetOffice365ActivationsUserCountsRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="office365activationsusercounts">The Office365ActivationsUserCounts object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetOffice365ActivationsUserCountsCollectionPage> PatchAsync(Office365ActivationsUserCounts office365activationsusercounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetOffice365ActivationsUserCountsCollectionPage> PatchAsync(Office365ActivationsUserCounts office365activationsusercounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="office365activationsusercounts">The Office365ActivationsUserCounts object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetOffice365ActivationsUserCountsCollectionPage> PutAsync(Office365ActivationsUserCounts office365activationsusercounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetOffice365ActivationsUserCountsCollectionPage> PutAsync(Office365ActivationsUserCounts office365activationsusercounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetOffice365ActivationsUserDetailRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetOffice365ActivationsUserDetailRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="office365activationsuserdetail">The Office365ActivationsUserDetail object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetOffice365ActivationsUserDetailCollectionPage> PatchAsync(Office365ActivationsUserDetail office365activationsuserdetail, 
+        public async System.Threading.Tasks.Task<IReportRootGetOffice365ActivationsUserDetailCollectionPage> PatchAsync(Office365ActivationsUserDetail office365activationsuserdetail,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="office365activationsuserdetail">The Office365ActivationsUserDetail object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetOffice365ActivationsUserDetailCollectionPage> PutAsync(Office365ActivationsUserDetail office365activationsuserdetail, 
+        public async System.Threading.Tasks.Task<IReportRootGetOffice365ActivationsUserDetailCollectionPage> PutAsync(Office365ActivationsUserDetail office365activationsuserdetail,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetOffice365ActiveUserCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetOffice365ActiveUserCountsRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="office365activeusercounts">The Office365ActiveUserCounts object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetOffice365ActiveUserCountsCollectionPage> PatchAsync(Office365ActiveUserCounts office365activeusercounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetOffice365ActiveUserCountsCollectionPage> PatchAsync(Office365ActiveUserCounts office365activeusercounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="office365activeusercounts">The Office365ActiveUserCounts object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetOffice365ActiveUserCountsCollectionPage> PutAsync(Office365ActiveUserCounts office365activeusercounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetOffice365ActiveUserCountsCollectionPage> PutAsync(Office365ActiveUserCounts office365activeusercounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetOffice365ActiveUserDetailRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetOffice365ActiveUserDetailRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="office365activeuserdetail">The Office365ActiveUserDetail object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetOffice365ActiveUserDetailCollectionPage> PatchAsync(Office365ActiveUserDetail office365activeuserdetail, 
+        public async System.Threading.Tasks.Task<IReportRootGetOffice365ActiveUserDetailCollectionPage> PatchAsync(Office365ActiveUserDetail office365activeuserdetail,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="office365activeuserdetail">The Office365ActiveUserDetail object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetOffice365ActiveUserDetailCollectionPage> PutAsync(Office365ActiveUserDetail office365activeuserdetail, 
+        public async System.Threading.Tasks.Task<IReportRootGetOffice365ActiveUserDetailCollectionPage> PutAsync(Office365ActiveUserDetail office365activeuserdetail,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetOffice365GroupsActivityCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetOffice365GroupsActivityCountsRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="office365groupsactivitycounts">The Office365GroupsActivityCounts object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetOffice365GroupsActivityCountsCollectionPage> PatchAsync(Office365GroupsActivityCounts office365groupsactivitycounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetOffice365GroupsActivityCountsCollectionPage> PatchAsync(Office365GroupsActivityCounts office365groupsactivitycounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="office365groupsactivitycounts">The Office365GroupsActivityCounts object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetOffice365GroupsActivityCountsCollectionPage> PutAsync(Office365GroupsActivityCounts office365groupsactivitycounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetOffice365GroupsActivityCountsCollectionPage> PutAsync(Office365GroupsActivityCounts office365groupsactivitycounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetOffice365GroupsActivityDetailRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetOffice365GroupsActivityDetailRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="office365groupsactivitydetail">The Office365GroupsActivityDetail object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetOffice365GroupsActivityDetailCollectionPage> PatchAsync(Office365GroupsActivityDetail office365groupsactivitydetail, 
+        public async System.Threading.Tasks.Task<IReportRootGetOffice365GroupsActivityDetailCollectionPage> PatchAsync(Office365GroupsActivityDetail office365groupsactivitydetail,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="office365groupsactivitydetail">The Office365GroupsActivityDetail object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetOffice365GroupsActivityDetailCollectionPage> PutAsync(Office365GroupsActivityDetail office365groupsactivitydetail, 
+        public async System.Threading.Tasks.Task<IReportRootGetOffice365GroupsActivityDetailCollectionPage> PutAsync(Office365GroupsActivityDetail office365groupsactivitydetail,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetOffice365GroupsActivityFileCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetOffice365GroupsActivityFileCountsRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="office365groupsactivityfilecounts">The Office365GroupsActivityFileCounts object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetOffice365GroupsActivityFileCountsCollectionPage> PatchAsync(Office365GroupsActivityFileCounts office365groupsactivityfilecounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetOffice365GroupsActivityFileCountsCollectionPage> PatchAsync(Office365GroupsActivityFileCounts office365groupsactivityfilecounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="office365groupsactivityfilecounts">The Office365GroupsActivityFileCounts object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetOffice365GroupsActivityFileCountsCollectionPage> PutAsync(Office365GroupsActivityFileCounts office365groupsactivityfilecounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetOffice365GroupsActivityFileCountsCollectionPage> PutAsync(Office365GroupsActivityFileCounts office365groupsactivityfilecounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetOffice365GroupsActivityGroupCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetOffice365GroupsActivityGroupCountsRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="office365groupsactivitygroupcounts">The Office365GroupsActivityGroupCounts object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetOffice365GroupsActivityGroupCountsCollectionPage> PatchAsync(Office365GroupsActivityGroupCounts office365groupsactivitygroupcounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetOffice365GroupsActivityGroupCountsCollectionPage> PatchAsync(Office365GroupsActivityGroupCounts office365groupsactivitygroupcounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="office365groupsactivitygroupcounts">The Office365GroupsActivityGroupCounts object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetOffice365GroupsActivityGroupCountsCollectionPage> PutAsync(Office365GroupsActivityGroupCounts office365groupsactivitygroupcounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetOffice365GroupsActivityGroupCountsCollectionPage> PutAsync(Office365GroupsActivityGroupCounts office365groupsactivitygroupcounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetOffice365GroupsActivityStorageRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetOffice365GroupsActivityStorageRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="office365groupsactivitystorage">The Office365GroupsActivityStorage object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetOffice365GroupsActivityStorageCollectionPage> PatchAsync(Office365GroupsActivityStorage office365groupsactivitystorage, 
+        public async System.Threading.Tasks.Task<IReportRootGetOffice365GroupsActivityStorageCollectionPage> PatchAsync(Office365GroupsActivityStorage office365groupsactivitystorage,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="office365groupsactivitystorage">The Office365GroupsActivityStorage object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetOffice365GroupsActivityStorageCollectionPage> PutAsync(Office365GroupsActivityStorage office365groupsactivitystorage, 
+        public async System.Threading.Tasks.Task<IReportRootGetOffice365GroupsActivityStorageCollectionPage> PutAsync(Office365GroupsActivityStorage office365groupsactivitystorage,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetOffice365ServicesUserCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetOffice365ServicesUserCountsRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="office365servicesusercounts">The Office365ServicesUserCounts object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetOffice365ServicesUserCountsCollectionPage> PatchAsync(Office365ServicesUserCounts office365servicesusercounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetOffice365ServicesUserCountsCollectionPage> PatchAsync(Office365ServicesUserCounts office365servicesusercounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="office365servicesusercounts">The Office365ServicesUserCounts object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetOffice365ServicesUserCountsCollectionPage> PutAsync(Office365ServicesUserCounts office365servicesusercounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetOffice365ServicesUserCountsCollectionPage> PutAsync(Office365ServicesUserCounts office365servicesusercounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetOneDriveActivityFileCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetOneDriveActivityFileCountsRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="siteactivitysummary">The SiteActivitySummary object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetOneDriveActivityFileCountsCollectionPage> PatchAsync(SiteActivitySummary siteactivitysummary, 
+        public async System.Threading.Tasks.Task<IReportRootGetOneDriveActivityFileCountsCollectionPage> PatchAsync(SiteActivitySummary siteactivitysummary,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="siteactivitysummary">The SiteActivitySummary object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetOneDriveActivityFileCountsCollectionPage> PutAsync(SiteActivitySummary siteactivitysummary, 
+        public async System.Threading.Tasks.Task<IReportRootGetOneDriveActivityFileCountsCollectionPage> PutAsync(SiteActivitySummary siteactivitysummary,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetOneDriveActivityUserCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetOneDriveActivityUserCountsRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="siteactivitysummary">The SiteActivitySummary object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetOneDriveActivityUserCountsCollectionPage> PatchAsync(SiteActivitySummary siteactivitysummary, 
+        public async System.Threading.Tasks.Task<IReportRootGetOneDriveActivityUserCountsCollectionPage> PatchAsync(SiteActivitySummary siteactivitysummary,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="siteactivitysummary">The SiteActivitySummary object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetOneDriveActivityUserCountsCollectionPage> PutAsync(SiteActivitySummary siteactivitysummary, 
+        public async System.Threading.Tasks.Task<IReportRootGetOneDriveActivityUserCountsCollectionPage> PutAsync(SiteActivitySummary siteactivitysummary,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetOneDriveActivityUserDetailRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetOneDriveActivityUserDetailRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="onedriveactivityuserdetail">The OneDriveActivityUserDetail object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetOneDriveActivityUserDetailCollectionPage> PatchAsync(OneDriveActivityUserDetail onedriveactivityuserdetail, 
+        public async System.Threading.Tasks.Task<IReportRootGetOneDriveActivityUserDetailCollectionPage> PatchAsync(OneDriveActivityUserDetail onedriveactivityuserdetail,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="onedriveactivityuserdetail">The OneDriveActivityUserDetail object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetOneDriveActivityUserDetailCollectionPage> PutAsync(OneDriveActivityUserDetail onedriveactivityuserdetail, 
+        public async System.Threading.Tasks.Task<IReportRootGetOneDriveActivityUserDetailCollectionPage> PutAsync(OneDriveActivityUserDetail onedriveactivityuserdetail,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetOneDriveUsageAccountCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetOneDriveUsageAccountCountsRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="onedriveusageaccountcounts">The OneDriveUsageAccountCounts object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetOneDriveUsageAccountCountsCollectionPage> PatchAsync(OneDriveUsageAccountCounts onedriveusageaccountcounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetOneDriveUsageAccountCountsCollectionPage> PatchAsync(OneDriveUsageAccountCounts onedriveusageaccountcounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="onedriveusageaccountcounts">The OneDriveUsageAccountCounts object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetOneDriveUsageAccountCountsCollectionPage> PutAsync(OneDriveUsageAccountCounts onedriveusageaccountcounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetOneDriveUsageAccountCountsCollectionPage> PutAsync(OneDriveUsageAccountCounts onedriveusageaccountcounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetOneDriveUsageAccountDetailRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetOneDriveUsageAccountDetailRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="onedriveusageaccountdetail">The OneDriveUsageAccountDetail object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetOneDriveUsageAccountDetailCollectionPage> PatchAsync(OneDriveUsageAccountDetail onedriveusageaccountdetail, 
+        public async System.Threading.Tasks.Task<IReportRootGetOneDriveUsageAccountDetailCollectionPage> PatchAsync(OneDriveUsageAccountDetail onedriveusageaccountdetail,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="onedriveusageaccountdetail">The OneDriveUsageAccountDetail object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetOneDriveUsageAccountDetailCollectionPage> PutAsync(OneDriveUsageAccountDetail onedriveusageaccountdetail, 
+        public async System.Threading.Tasks.Task<IReportRootGetOneDriveUsageAccountDetailCollectionPage> PutAsync(OneDriveUsageAccountDetail onedriveusageaccountdetail,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetOneDriveUsageFileCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetOneDriveUsageFileCountsRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="onedriveusagefilecounts">The OneDriveUsageFileCounts object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetOneDriveUsageFileCountsCollectionPage> PatchAsync(OneDriveUsageFileCounts onedriveusagefilecounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetOneDriveUsageFileCountsCollectionPage> PatchAsync(OneDriveUsageFileCounts onedriveusagefilecounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="onedriveusagefilecounts">The OneDriveUsageFileCounts object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetOneDriveUsageFileCountsCollectionPage> PutAsync(OneDriveUsageFileCounts onedriveusagefilecounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetOneDriveUsageFileCountsCollectionPage> PutAsync(OneDriveUsageFileCounts onedriveusagefilecounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetOneDriveUsageStorageRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetOneDriveUsageStorageRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="siteusagestorage">The SiteUsageStorage object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetOneDriveUsageStorageCollectionPage> PatchAsync(SiteUsageStorage siteusagestorage, 
+        public async System.Threading.Tasks.Task<IReportRootGetOneDriveUsageStorageCollectionPage> PatchAsync(SiteUsageStorage siteusagestorage,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="siteusagestorage">The SiteUsageStorage object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetOneDriveUsageStorageCollectionPage> PutAsync(SiteUsageStorage siteusagestorage, 
+        public async System.Threading.Tasks.Task<IReportRootGetOneDriveUsageStorageCollectionPage> PutAsync(SiteUsageStorage siteusagestorage,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetRelyingPartyDetailedSummaryRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetRelyingPartyDetailedSummaryRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="relyingpartydetailedsummary">The RelyingPartyDetailedSummary object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetRelyingPartyDetailedSummaryCollectionPage> PatchAsync(RelyingPartyDetailedSummary relyingpartydetailedsummary, 
+        public async System.Threading.Tasks.Task<IReportRootGetRelyingPartyDetailedSummaryCollectionPage> PatchAsync(RelyingPartyDetailedSummary relyingpartydetailedsummary,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="relyingpartydetailedsummary">The RelyingPartyDetailedSummary object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetRelyingPartyDetailedSummaryCollectionPage> PutAsync(RelyingPartyDetailedSummary relyingpartydetailedsummary, 
+        public async System.Threading.Tasks.Task<IReportRootGetRelyingPartyDetailedSummaryCollectionPage> PutAsync(RelyingPartyDetailedSummary relyingpartydetailedsummary,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetSharePointActivityFileCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetSharePointActivityFileCountsRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="siteactivitysummary">The SiteActivitySummary object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetSharePointActivityFileCountsCollectionPage> PatchAsync(SiteActivitySummary siteactivitysummary, 
+        public async System.Threading.Tasks.Task<IReportRootGetSharePointActivityFileCountsCollectionPage> PatchAsync(SiteActivitySummary siteactivitysummary,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="siteactivitysummary">The SiteActivitySummary object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetSharePointActivityFileCountsCollectionPage> PutAsync(SiteActivitySummary siteactivitysummary, 
+        public async System.Threading.Tasks.Task<IReportRootGetSharePointActivityFileCountsCollectionPage> PutAsync(SiteActivitySummary siteactivitysummary,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetSharePointActivityPagesRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetSharePointActivityPagesRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="sharepointactivitypages">The SharePointActivityPages object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetSharePointActivityPagesCollectionPage> PatchAsync(SharePointActivityPages sharepointactivitypages, 
+        public async System.Threading.Tasks.Task<IReportRootGetSharePointActivityPagesCollectionPage> PatchAsync(SharePointActivityPages sharepointactivitypages,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="sharepointactivitypages">The SharePointActivityPages object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetSharePointActivityPagesCollectionPage> PutAsync(SharePointActivityPages sharepointactivitypages, 
+        public async System.Threading.Tasks.Task<IReportRootGetSharePointActivityPagesCollectionPage> PutAsync(SharePointActivityPages sharepointactivitypages,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetSharePointActivityUserCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetSharePointActivityUserCountsRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="sharepointactivityusercounts">The SharePointActivityUserCounts object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetSharePointActivityUserCountsCollectionPage> PatchAsync(SharePointActivityUserCounts sharepointactivityusercounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetSharePointActivityUserCountsCollectionPage> PatchAsync(SharePointActivityUserCounts sharepointactivityusercounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="sharepointactivityusercounts">The SharePointActivityUserCounts object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetSharePointActivityUserCountsCollectionPage> PutAsync(SharePointActivityUserCounts sharepointactivityusercounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetSharePointActivityUserCountsCollectionPage> PutAsync(SharePointActivityUserCounts sharepointactivityusercounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetSharePointActivityUserDetailRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetSharePointActivityUserDetailRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="sharepointactivityuserdetail">The SharePointActivityUserDetail object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetSharePointActivityUserDetailCollectionPage> PatchAsync(SharePointActivityUserDetail sharepointactivityuserdetail, 
+        public async System.Threading.Tasks.Task<IReportRootGetSharePointActivityUserDetailCollectionPage> PatchAsync(SharePointActivityUserDetail sharepointactivityuserdetail,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="sharepointactivityuserdetail">The SharePointActivityUserDetail object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetSharePointActivityUserDetailCollectionPage> PutAsync(SharePointActivityUserDetail sharepointactivityuserdetail, 
+        public async System.Threading.Tasks.Task<IReportRootGetSharePointActivityUserDetailCollectionPage> PutAsync(SharePointActivityUserDetail sharepointactivityuserdetail,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetSharePointSiteUsageDetailRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetSharePointSiteUsageDetailRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="sharepointsiteusagedetail">The SharePointSiteUsageDetail object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetSharePointSiteUsageDetailCollectionPage> PatchAsync(SharePointSiteUsageDetail sharepointsiteusagedetail, 
+        public async System.Threading.Tasks.Task<IReportRootGetSharePointSiteUsageDetailCollectionPage> PatchAsync(SharePointSiteUsageDetail sharepointsiteusagedetail,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="sharepointsiteusagedetail">The SharePointSiteUsageDetail object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetSharePointSiteUsageDetailCollectionPage> PutAsync(SharePointSiteUsageDetail sharepointsiteusagedetail, 
+        public async System.Threading.Tasks.Task<IReportRootGetSharePointSiteUsageDetailCollectionPage> PutAsync(SharePointSiteUsageDetail sharepointsiteusagedetail,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetSharePointSiteUsageFileCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetSharePointSiteUsageFileCountsRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="sharepointsiteusagefilecounts">The SharePointSiteUsageFileCounts object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetSharePointSiteUsageFileCountsCollectionPage> PatchAsync(SharePointSiteUsageFileCounts sharepointsiteusagefilecounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetSharePointSiteUsageFileCountsCollectionPage> PatchAsync(SharePointSiteUsageFileCounts sharepointsiteusagefilecounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="sharepointsiteusagefilecounts">The SharePointSiteUsageFileCounts object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetSharePointSiteUsageFileCountsCollectionPage> PutAsync(SharePointSiteUsageFileCounts sharepointsiteusagefilecounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetSharePointSiteUsageFileCountsCollectionPage> PutAsync(SharePointSiteUsageFileCounts sharepointsiteusagefilecounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetSharePointSiteUsagePagesRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetSharePointSiteUsagePagesRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="sharepointsiteusagepages">The SharePointSiteUsagePages object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetSharePointSiteUsagePagesCollectionPage> PatchAsync(SharePointSiteUsagePages sharepointsiteusagepages, 
+        public async System.Threading.Tasks.Task<IReportRootGetSharePointSiteUsagePagesCollectionPage> PatchAsync(SharePointSiteUsagePages sharepointsiteusagepages,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="sharepointsiteusagepages">The SharePointSiteUsagePages object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetSharePointSiteUsagePagesCollectionPage> PutAsync(SharePointSiteUsagePages sharepointsiteusagepages, 
+        public async System.Threading.Tasks.Task<IReportRootGetSharePointSiteUsagePagesCollectionPage> PutAsync(SharePointSiteUsagePages sharepointsiteusagepages,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetSharePointSiteUsageSiteCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetSharePointSiteUsageSiteCountsRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="sharepointsiteusagesitecounts">The SharePointSiteUsageSiteCounts object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetSharePointSiteUsageSiteCountsCollectionPage> PatchAsync(SharePointSiteUsageSiteCounts sharepointsiteusagesitecounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetSharePointSiteUsageSiteCountsCollectionPage> PatchAsync(SharePointSiteUsageSiteCounts sharepointsiteusagesitecounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="sharepointsiteusagesitecounts">The SharePointSiteUsageSiteCounts object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetSharePointSiteUsageSiteCountsCollectionPage> PutAsync(SharePointSiteUsageSiteCounts sharepointsiteusagesitecounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetSharePointSiteUsageSiteCountsCollectionPage> PutAsync(SharePointSiteUsageSiteCounts sharepointsiteusagesitecounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetSharePointSiteUsageStorageRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetSharePointSiteUsageStorageRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="siteusagestorage">The SiteUsageStorage object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetSharePointSiteUsageStorageCollectionPage> PatchAsync(SiteUsageStorage siteusagestorage, 
+        public async System.Threading.Tasks.Task<IReportRootGetSharePointSiteUsageStorageCollectionPage> PatchAsync(SiteUsageStorage siteusagestorage,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="siteusagestorage">The SiteUsageStorage object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetSharePointSiteUsageStorageCollectionPage> PutAsync(SiteUsageStorage siteusagestorage, 
+        public async System.Threading.Tasks.Task<IReportRootGetSharePointSiteUsageStorageCollectionPage> PutAsync(SiteUsageStorage siteusagestorage,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetSkypeForBusinessActivityCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetSkypeForBusinessActivityCountsRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="skypeforbusinessactivitycounts">The SkypeForBusinessActivityCounts object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetSkypeForBusinessActivityCountsCollectionPage> PatchAsync(SkypeForBusinessActivityCounts skypeforbusinessactivitycounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetSkypeForBusinessActivityCountsCollectionPage> PatchAsync(SkypeForBusinessActivityCounts skypeforbusinessactivitycounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="skypeforbusinessactivitycounts">The SkypeForBusinessActivityCounts object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetSkypeForBusinessActivityCountsCollectionPage> PutAsync(SkypeForBusinessActivityCounts skypeforbusinessactivitycounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetSkypeForBusinessActivityCountsCollectionPage> PutAsync(SkypeForBusinessActivityCounts skypeforbusinessactivitycounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetSkypeForBusinessActivityUserCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetSkypeForBusinessActivityUserCountsRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="skypeforbusinessactivityusercounts">The SkypeForBusinessActivityUserCounts object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetSkypeForBusinessActivityUserCountsCollectionPage> PatchAsync(SkypeForBusinessActivityUserCounts skypeforbusinessactivityusercounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetSkypeForBusinessActivityUserCountsCollectionPage> PatchAsync(SkypeForBusinessActivityUserCounts skypeforbusinessactivityusercounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="skypeforbusinessactivityusercounts">The SkypeForBusinessActivityUserCounts object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetSkypeForBusinessActivityUserCountsCollectionPage> PutAsync(SkypeForBusinessActivityUserCounts skypeforbusinessactivityusercounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetSkypeForBusinessActivityUserCountsCollectionPage> PutAsync(SkypeForBusinessActivityUserCounts skypeforbusinessactivityusercounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetSkypeForBusinessActivityUserDetailRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetSkypeForBusinessActivityUserDetailRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="skypeforbusinessactivityuserdetail">The SkypeForBusinessActivityUserDetail object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetSkypeForBusinessActivityUserDetailCollectionPage> PatchAsync(SkypeForBusinessActivityUserDetail skypeforbusinessactivityuserdetail, 
+        public async System.Threading.Tasks.Task<IReportRootGetSkypeForBusinessActivityUserDetailCollectionPage> PatchAsync(SkypeForBusinessActivityUserDetail skypeforbusinessactivityuserdetail,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="skypeforbusinessactivityuserdetail">The SkypeForBusinessActivityUserDetail object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetSkypeForBusinessActivityUserDetailCollectionPage> PutAsync(SkypeForBusinessActivityUserDetail skypeforbusinessactivityuserdetail, 
+        public async System.Threading.Tasks.Task<IReportRootGetSkypeForBusinessActivityUserDetailCollectionPage> PutAsync(SkypeForBusinessActivityUserDetail skypeforbusinessactivityuserdetail,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetSkypeForBusinessDeviceUsageDistributionUserCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetSkypeForBusinessDeviceUsageDistributionUserCountsRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="skypeforbusinessdeviceusagedistributionusercounts">The SkypeForBusinessDeviceUsageDistributionUserCounts object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetSkypeForBusinessDeviceUsageDistributionUserCountsCollectionPage> PatchAsync(SkypeForBusinessDeviceUsageDistributionUserCounts skypeforbusinessdeviceusagedistributionusercounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetSkypeForBusinessDeviceUsageDistributionUserCountsCollectionPage> PatchAsync(SkypeForBusinessDeviceUsageDistributionUserCounts skypeforbusinessdeviceusagedistributionusercounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="skypeforbusinessdeviceusagedistributionusercounts">The SkypeForBusinessDeviceUsageDistributionUserCounts object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetSkypeForBusinessDeviceUsageDistributionUserCountsCollectionPage> PutAsync(SkypeForBusinessDeviceUsageDistributionUserCounts skypeforbusinessdeviceusagedistributionusercounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetSkypeForBusinessDeviceUsageDistributionUserCountsCollectionPage> PutAsync(SkypeForBusinessDeviceUsageDistributionUserCounts skypeforbusinessdeviceusagedistributionusercounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetSkypeForBusinessDeviceUsageUserCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetSkypeForBusinessDeviceUsageUserCountsRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="skypeforbusinessdeviceusageusercounts">The SkypeForBusinessDeviceUsageUserCounts object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetSkypeForBusinessDeviceUsageUserCountsCollectionPage> PatchAsync(SkypeForBusinessDeviceUsageUserCounts skypeforbusinessdeviceusageusercounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetSkypeForBusinessDeviceUsageUserCountsCollectionPage> PatchAsync(SkypeForBusinessDeviceUsageUserCounts skypeforbusinessdeviceusageusercounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="skypeforbusinessdeviceusageusercounts">The SkypeForBusinessDeviceUsageUserCounts object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetSkypeForBusinessDeviceUsageUserCountsCollectionPage> PutAsync(SkypeForBusinessDeviceUsageUserCounts skypeforbusinessdeviceusageusercounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetSkypeForBusinessDeviceUsageUserCountsCollectionPage> PutAsync(SkypeForBusinessDeviceUsageUserCounts skypeforbusinessdeviceusageusercounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetSkypeForBusinessDeviceUsageUserDetailRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetSkypeForBusinessDeviceUsageUserDetailRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="skypeforbusinessdeviceusageuserdetail">The SkypeForBusinessDeviceUsageUserDetail object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetSkypeForBusinessDeviceUsageUserDetailCollectionPage> PatchAsync(SkypeForBusinessDeviceUsageUserDetail skypeforbusinessdeviceusageuserdetail, 
+        public async System.Threading.Tasks.Task<IReportRootGetSkypeForBusinessDeviceUsageUserDetailCollectionPage> PatchAsync(SkypeForBusinessDeviceUsageUserDetail skypeforbusinessdeviceusageuserdetail,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="skypeforbusinessdeviceusageuserdetail">The SkypeForBusinessDeviceUsageUserDetail object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetSkypeForBusinessDeviceUsageUserDetailCollectionPage> PutAsync(SkypeForBusinessDeviceUsageUserDetail skypeforbusinessdeviceusageuserdetail, 
+        public async System.Threading.Tasks.Task<IReportRootGetSkypeForBusinessDeviceUsageUserDetailCollectionPage> PutAsync(SkypeForBusinessDeviceUsageUserDetail skypeforbusinessdeviceusageuserdetail,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetSkypeForBusinessOrganizerActivityCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetSkypeForBusinessOrganizerActivityCountsRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="skypeforbusinessorganizeractivitycounts">The SkypeForBusinessOrganizerActivityCounts object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetSkypeForBusinessOrganizerActivityCountsCollectionPage> PatchAsync(SkypeForBusinessOrganizerActivityCounts skypeforbusinessorganizeractivitycounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetSkypeForBusinessOrganizerActivityCountsCollectionPage> PatchAsync(SkypeForBusinessOrganizerActivityCounts skypeforbusinessorganizeractivitycounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="skypeforbusinessorganizeractivitycounts">The SkypeForBusinessOrganizerActivityCounts object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetSkypeForBusinessOrganizerActivityCountsCollectionPage> PutAsync(SkypeForBusinessOrganizerActivityCounts skypeforbusinessorganizeractivitycounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetSkypeForBusinessOrganizerActivityCountsCollectionPage> PutAsync(SkypeForBusinessOrganizerActivityCounts skypeforbusinessorganizeractivitycounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetSkypeForBusinessOrganizerActivityMinuteCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetSkypeForBusinessOrganizerActivityMinuteCountsRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="skypeforbusinessorganizeractivityminutecounts">The SkypeForBusinessOrganizerActivityMinuteCounts object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetSkypeForBusinessOrganizerActivityMinuteCountsCollectionPage> PatchAsync(SkypeForBusinessOrganizerActivityMinuteCounts skypeforbusinessorganizeractivityminutecounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetSkypeForBusinessOrganizerActivityMinuteCountsCollectionPage> PatchAsync(SkypeForBusinessOrganizerActivityMinuteCounts skypeforbusinessorganizeractivityminutecounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="skypeforbusinessorganizeractivityminutecounts">The SkypeForBusinessOrganizerActivityMinuteCounts object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetSkypeForBusinessOrganizerActivityMinuteCountsCollectionPage> PutAsync(SkypeForBusinessOrganizerActivityMinuteCounts skypeforbusinessorganizeractivityminutecounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetSkypeForBusinessOrganizerActivityMinuteCountsCollectionPage> PutAsync(SkypeForBusinessOrganizerActivityMinuteCounts skypeforbusinessorganizeractivityminutecounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetSkypeForBusinessOrganizerActivityUserCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetSkypeForBusinessOrganizerActivityUserCountsRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="skypeforbusinessorganizeractivityusercounts">The SkypeForBusinessOrganizerActivityUserCounts object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetSkypeForBusinessOrganizerActivityUserCountsCollectionPage> PatchAsync(SkypeForBusinessOrganizerActivityUserCounts skypeforbusinessorganizeractivityusercounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetSkypeForBusinessOrganizerActivityUserCountsCollectionPage> PatchAsync(SkypeForBusinessOrganizerActivityUserCounts skypeforbusinessorganizeractivityusercounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="skypeforbusinessorganizeractivityusercounts">The SkypeForBusinessOrganizerActivityUserCounts object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetSkypeForBusinessOrganizerActivityUserCountsCollectionPage> PutAsync(SkypeForBusinessOrganizerActivityUserCounts skypeforbusinessorganizeractivityusercounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetSkypeForBusinessOrganizerActivityUserCountsCollectionPage> PutAsync(SkypeForBusinessOrganizerActivityUserCounts skypeforbusinessorganizeractivityusercounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetSkypeForBusinessParticipantActivityCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetSkypeForBusinessParticipantActivityCountsRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="skypeforbusinessparticipantactivitycounts">The SkypeForBusinessParticipantActivityCounts object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetSkypeForBusinessParticipantActivityCountsCollectionPage> PatchAsync(SkypeForBusinessParticipantActivityCounts skypeforbusinessparticipantactivitycounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetSkypeForBusinessParticipantActivityCountsCollectionPage> PatchAsync(SkypeForBusinessParticipantActivityCounts skypeforbusinessparticipantactivitycounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="skypeforbusinessparticipantactivitycounts">The SkypeForBusinessParticipantActivityCounts object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetSkypeForBusinessParticipantActivityCountsCollectionPage> PutAsync(SkypeForBusinessParticipantActivityCounts skypeforbusinessparticipantactivitycounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetSkypeForBusinessParticipantActivityCountsCollectionPage> PutAsync(SkypeForBusinessParticipantActivityCounts skypeforbusinessparticipantactivitycounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetSkypeForBusinessParticipantActivityMinuteCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetSkypeForBusinessParticipantActivityMinuteCountsRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="skypeforbusinessparticipantactivityminutecounts">The SkypeForBusinessParticipantActivityMinuteCounts object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetSkypeForBusinessParticipantActivityMinuteCountsCollectionPage> PatchAsync(SkypeForBusinessParticipantActivityMinuteCounts skypeforbusinessparticipantactivityminutecounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetSkypeForBusinessParticipantActivityMinuteCountsCollectionPage> PatchAsync(SkypeForBusinessParticipantActivityMinuteCounts skypeforbusinessparticipantactivityminutecounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="skypeforbusinessparticipantactivityminutecounts">The SkypeForBusinessParticipantActivityMinuteCounts object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetSkypeForBusinessParticipantActivityMinuteCountsCollectionPage> PutAsync(SkypeForBusinessParticipantActivityMinuteCounts skypeforbusinessparticipantactivityminutecounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetSkypeForBusinessParticipantActivityMinuteCountsCollectionPage> PutAsync(SkypeForBusinessParticipantActivityMinuteCounts skypeforbusinessparticipantactivityminutecounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetSkypeForBusinessParticipantActivityUserCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetSkypeForBusinessParticipantActivityUserCountsRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="skypeforbusinessparticipantactivityusercounts">The SkypeForBusinessParticipantActivityUserCounts object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetSkypeForBusinessParticipantActivityUserCountsCollectionPage> PatchAsync(SkypeForBusinessParticipantActivityUserCounts skypeforbusinessparticipantactivityusercounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetSkypeForBusinessParticipantActivityUserCountsCollectionPage> PatchAsync(SkypeForBusinessParticipantActivityUserCounts skypeforbusinessparticipantactivityusercounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="skypeforbusinessparticipantactivityusercounts">The SkypeForBusinessParticipantActivityUserCounts object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetSkypeForBusinessParticipantActivityUserCountsCollectionPage> PutAsync(SkypeForBusinessParticipantActivityUserCounts skypeforbusinessparticipantactivityusercounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetSkypeForBusinessParticipantActivityUserCountsCollectionPage> PutAsync(SkypeForBusinessParticipantActivityUserCounts skypeforbusinessparticipantactivityusercounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetSkypeForBusinessPeerToPeerActivityCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetSkypeForBusinessPeerToPeerActivityCountsRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="skypeforbusinesspeertopeeractivitycounts">The SkypeForBusinessPeerToPeerActivityCounts object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetSkypeForBusinessPeerToPeerActivityCountsCollectionPage> PatchAsync(SkypeForBusinessPeerToPeerActivityCounts skypeforbusinesspeertopeeractivitycounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetSkypeForBusinessPeerToPeerActivityCountsCollectionPage> PatchAsync(SkypeForBusinessPeerToPeerActivityCounts skypeforbusinesspeertopeeractivitycounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="skypeforbusinesspeertopeeractivitycounts">The SkypeForBusinessPeerToPeerActivityCounts object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetSkypeForBusinessPeerToPeerActivityCountsCollectionPage> PutAsync(SkypeForBusinessPeerToPeerActivityCounts skypeforbusinesspeertopeeractivitycounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetSkypeForBusinessPeerToPeerActivityCountsCollectionPage> PutAsync(SkypeForBusinessPeerToPeerActivityCounts skypeforbusinesspeertopeeractivitycounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetSkypeForBusinessPeerToPeerActivityMinuteCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetSkypeForBusinessPeerToPeerActivityMinuteCountsRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="skypeforbusinesspeertopeeractivityminutecounts">The SkypeForBusinessPeerToPeerActivityMinuteCounts object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetSkypeForBusinessPeerToPeerActivityMinuteCountsCollectionPage> PatchAsync(SkypeForBusinessPeerToPeerActivityMinuteCounts skypeforbusinesspeertopeeractivityminutecounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetSkypeForBusinessPeerToPeerActivityMinuteCountsCollectionPage> PatchAsync(SkypeForBusinessPeerToPeerActivityMinuteCounts skypeforbusinesspeertopeeractivityminutecounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="skypeforbusinesspeertopeeractivityminutecounts">The SkypeForBusinessPeerToPeerActivityMinuteCounts object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetSkypeForBusinessPeerToPeerActivityMinuteCountsCollectionPage> PutAsync(SkypeForBusinessPeerToPeerActivityMinuteCounts skypeforbusinesspeertopeeractivityminutecounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetSkypeForBusinessPeerToPeerActivityMinuteCountsCollectionPage> PutAsync(SkypeForBusinessPeerToPeerActivityMinuteCounts skypeforbusinesspeertopeeractivityminutecounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetSkypeForBusinessPeerToPeerActivityUserCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetSkypeForBusinessPeerToPeerActivityUserCountsRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="skypeforbusinesspeertopeeractivityusercounts">The SkypeForBusinessPeerToPeerActivityUserCounts object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetSkypeForBusinessPeerToPeerActivityUserCountsCollectionPage> PatchAsync(SkypeForBusinessPeerToPeerActivityUserCounts skypeforbusinesspeertopeeractivityusercounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetSkypeForBusinessPeerToPeerActivityUserCountsCollectionPage> PatchAsync(SkypeForBusinessPeerToPeerActivityUserCounts skypeforbusinesspeertopeeractivityusercounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="skypeforbusinesspeertopeeractivityusercounts">The SkypeForBusinessPeerToPeerActivityUserCounts object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetSkypeForBusinessPeerToPeerActivityUserCountsCollectionPage> PutAsync(SkypeForBusinessPeerToPeerActivityUserCounts skypeforbusinesspeertopeeractivityusercounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetSkypeForBusinessPeerToPeerActivityUserCountsCollectionPage> PutAsync(SkypeForBusinessPeerToPeerActivityUserCounts skypeforbusinesspeertopeeractivityusercounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetTeamsDeviceUsageDistributionUserCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetTeamsDeviceUsageDistributionUserCountsRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="teamsdeviceusagedistributionusercounts">The TeamsDeviceUsageDistributionUserCounts object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetTeamsDeviceUsageDistributionUserCountsCollectionPage> PatchAsync(TeamsDeviceUsageDistributionUserCounts teamsdeviceusagedistributionusercounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetTeamsDeviceUsageDistributionUserCountsCollectionPage> PatchAsync(TeamsDeviceUsageDistributionUserCounts teamsdeviceusagedistributionusercounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="teamsdeviceusagedistributionusercounts">The TeamsDeviceUsageDistributionUserCounts object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetTeamsDeviceUsageDistributionUserCountsCollectionPage> PutAsync(TeamsDeviceUsageDistributionUserCounts teamsdeviceusagedistributionusercounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetTeamsDeviceUsageDistributionUserCountsCollectionPage> PutAsync(TeamsDeviceUsageDistributionUserCounts teamsdeviceusagedistributionusercounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetTeamsDeviceUsageUserCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetTeamsDeviceUsageUserCountsRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="teamsdeviceusageusercounts">The TeamsDeviceUsageUserCounts object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetTeamsDeviceUsageUserCountsCollectionPage> PatchAsync(TeamsDeviceUsageUserCounts teamsdeviceusageusercounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetTeamsDeviceUsageUserCountsCollectionPage> PatchAsync(TeamsDeviceUsageUserCounts teamsdeviceusageusercounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="teamsdeviceusageusercounts">The TeamsDeviceUsageUserCounts object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetTeamsDeviceUsageUserCountsCollectionPage> PutAsync(TeamsDeviceUsageUserCounts teamsdeviceusageusercounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetTeamsDeviceUsageUserCountsCollectionPage> PutAsync(TeamsDeviceUsageUserCounts teamsdeviceusageusercounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetTeamsDeviceUsageUserDetailRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetTeamsDeviceUsageUserDetailRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="teamsdeviceusageuserdetail">The TeamsDeviceUsageUserDetail object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetTeamsDeviceUsageUserDetailCollectionPage> PatchAsync(TeamsDeviceUsageUserDetail teamsdeviceusageuserdetail, 
+        public async System.Threading.Tasks.Task<IReportRootGetTeamsDeviceUsageUserDetailCollectionPage> PatchAsync(TeamsDeviceUsageUserDetail teamsdeviceusageuserdetail,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="teamsdeviceusageuserdetail">The TeamsDeviceUsageUserDetail object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetTeamsDeviceUsageUserDetailCollectionPage> PutAsync(TeamsDeviceUsageUserDetail teamsdeviceusageuserdetail, 
+        public async System.Threading.Tasks.Task<IReportRootGetTeamsDeviceUsageUserDetailCollectionPage> PutAsync(TeamsDeviceUsageUserDetail teamsdeviceusageuserdetail,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetTeamsUserActivityCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetTeamsUserActivityCountsRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="teamsuseractivitycounts">The TeamsUserActivityCounts object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetTeamsUserActivityCountsCollectionPage> PatchAsync(TeamsUserActivityCounts teamsuseractivitycounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetTeamsUserActivityCountsCollectionPage> PatchAsync(TeamsUserActivityCounts teamsuseractivitycounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="teamsuseractivitycounts">The TeamsUserActivityCounts object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetTeamsUserActivityCountsCollectionPage> PutAsync(TeamsUserActivityCounts teamsuseractivitycounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetTeamsUserActivityCountsCollectionPage> PutAsync(TeamsUserActivityCounts teamsuseractivitycounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetTeamsUserActivityUserCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetTeamsUserActivityUserCountsRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="teamsuseractivityusercounts">The TeamsUserActivityUserCounts object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetTeamsUserActivityUserCountsCollectionPage> PatchAsync(TeamsUserActivityUserCounts teamsuseractivityusercounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetTeamsUserActivityUserCountsCollectionPage> PatchAsync(TeamsUserActivityUserCounts teamsuseractivityusercounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="teamsuseractivityusercounts">The TeamsUserActivityUserCounts object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetTeamsUserActivityUserCountsCollectionPage> PutAsync(TeamsUserActivityUserCounts teamsuseractivityusercounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetTeamsUserActivityUserCountsCollectionPage> PutAsync(TeamsUserActivityUserCounts teamsuseractivityusercounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetTeamsUserActivityUserDetailRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetTeamsUserActivityUserDetailRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="teamsuseractivityuserdetail">The TeamsUserActivityUserDetail object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetTeamsUserActivityUserDetailCollectionPage> PatchAsync(TeamsUserActivityUserDetail teamsuseractivityuserdetail, 
+        public async System.Threading.Tasks.Task<IReportRootGetTeamsUserActivityUserDetailCollectionPage> PatchAsync(TeamsUserActivityUserDetail teamsuseractivityuserdetail,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="teamsuseractivityuserdetail">The TeamsUserActivityUserDetail object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetTeamsUserActivityUserDetailCollectionPage> PutAsync(TeamsUserActivityUserDetail teamsuseractivityuserdetail, 
+        public async System.Threading.Tasks.Task<IReportRootGetTeamsUserActivityUserDetailCollectionPage> PutAsync(TeamsUserActivityUserDetail teamsuseractivityuserdetail,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetTenantSecureScoresRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetTenantSecureScoresRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetYammerActivityCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetYammerActivityCountsRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="yammeractivitysummary">The YammerActivitySummary object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetYammerActivityCountsCollectionPage> PatchAsync(YammerActivitySummary yammeractivitysummary, 
+        public async System.Threading.Tasks.Task<IReportRootGetYammerActivityCountsCollectionPage> PatchAsync(YammerActivitySummary yammeractivitysummary,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="yammeractivitysummary">The YammerActivitySummary object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetYammerActivityCountsCollectionPage> PutAsync(YammerActivitySummary yammeractivitysummary, 
+        public async System.Threading.Tasks.Task<IReportRootGetYammerActivityCountsCollectionPage> PutAsync(YammerActivitySummary yammeractivitysummary,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetYammerActivityUserCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetYammerActivityUserCountsRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="yammeractivitysummary">The YammerActivitySummary object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetYammerActivityUserCountsCollectionPage> PatchAsync(YammerActivitySummary yammeractivitysummary, 
+        public async System.Threading.Tasks.Task<IReportRootGetYammerActivityUserCountsCollectionPage> PatchAsync(YammerActivitySummary yammeractivitysummary,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="yammeractivitysummary">The YammerActivitySummary object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetYammerActivityUserCountsCollectionPage> PutAsync(YammerActivitySummary yammeractivitysummary, 
+        public async System.Threading.Tasks.Task<IReportRootGetYammerActivityUserCountsCollectionPage> PutAsync(YammerActivitySummary yammeractivitysummary,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetYammerActivityUserDetailRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetYammerActivityUserDetailRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="yammeractivityuserdetail">The YammerActivityUserDetail object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetYammerActivityUserDetailCollectionPage> PatchAsync(YammerActivityUserDetail yammeractivityuserdetail, 
+        public async System.Threading.Tasks.Task<IReportRootGetYammerActivityUserDetailCollectionPage> PatchAsync(YammerActivityUserDetail yammeractivityuserdetail,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="yammeractivityuserdetail">The YammerActivityUserDetail object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetYammerActivityUserDetailCollectionPage> PutAsync(YammerActivityUserDetail yammeractivityuserdetail, 
+        public async System.Threading.Tasks.Task<IReportRootGetYammerActivityUserDetailCollectionPage> PutAsync(YammerActivityUserDetail yammeractivityuserdetail,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetYammerDeviceUsageDistributionUserCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetYammerDeviceUsageDistributionUserCountsRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="yammerdeviceusagedistributionusercounts">The YammerDeviceUsageDistributionUserCounts object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetYammerDeviceUsageDistributionUserCountsCollectionPage> PatchAsync(YammerDeviceUsageDistributionUserCounts yammerdeviceusagedistributionusercounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetYammerDeviceUsageDistributionUserCountsCollectionPage> PatchAsync(YammerDeviceUsageDistributionUserCounts yammerdeviceusagedistributionusercounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="yammerdeviceusagedistributionusercounts">The YammerDeviceUsageDistributionUserCounts object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetYammerDeviceUsageDistributionUserCountsCollectionPage> PutAsync(YammerDeviceUsageDistributionUserCounts yammerdeviceusagedistributionusercounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetYammerDeviceUsageDistributionUserCountsCollectionPage> PutAsync(YammerDeviceUsageDistributionUserCounts yammerdeviceusagedistributionusercounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetYammerDeviceUsageUserCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetYammerDeviceUsageUserCountsRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="yammerdeviceusageusercounts">The YammerDeviceUsageUserCounts object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetYammerDeviceUsageUserCountsCollectionPage> PatchAsync(YammerDeviceUsageUserCounts yammerdeviceusageusercounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetYammerDeviceUsageUserCountsCollectionPage> PatchAsync(YammerDeviceUsageUserCounts yammerdeviceusageusercounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="yammerdeviceusageusercounts">The YammerDeviceUsageUserCounts object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetYammerDeviceUsageUserCountsCollectionPage> PutAsync(YammerDeviceUsageUserCounts yammerdeviceusageusercounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetYammerDeviceUsageUserCountsCollectionPage> PutAsync(YammerDeviceUsageUserCounts yammerdeviceusageusercounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetYammerDeviceUsageUserDetailRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetYammerDeviceUsageUserDetailRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="yammerdeviceusageuserdetail">The YammerDeviceUsageUserDetail object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetYammerDeviceUsageUserDetailCollectionPage> PatchAsync(YammerDeviceUsageUserDetail yammerdeviceusageuserdetail, 
+        public async System.Threading.Tasks.Task<IReportRootGetYammerDeviceUsageUserDetailCollectionPage> PatchAsync(YammerDeviceUsageUserDetail yammerdeviceusageuserdetail,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="yammerdeviceusageuserdetail">The YammerDeviceUsageUserDetail object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetYammerDeviceUsageUserDetailCollectionPage> PutAsync(YammerDeviceUsageUserDetail yammerdeviceusageuserdetail, 
+        public async System.Threading.Tasks.Task<IReportRootGetYammerDeviceUsageUserDetailCollectionPage> PutAsync(YammerDeviceUsageUserDetail yammerdeviceusageuserdetail,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetYammerGroupsActivityCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetYammerGroupsActivityCountsRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="yammergroupsactivitycounts">The YammerGroupsActivityCounts object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetYammerGroupsActivityCountsCollectionPage> PatchAsync(YammerGroupsActivityCounts yammergroupsactivitycounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetYammerGroupsActivityCountsCollectionPage> PatchAsync(YammerGroupsActivityCounts yammergroupsactivitycounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="yammergroupsactivitycounts">The YammerGroupsActivityCounts object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetYammerGroupsActivityCountsCollectionPage> PutAsync(YammerGroupsActivityCounts yammergroupsactivitycounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetYammerGroupsActivityCountsCollectionPage> PutAsync(YammerGroupsActivityCounts yammergroupsactivitycounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetYammerGroupsActivityDetailRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetYammerGroupsActivityDetailRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="yammergroupsactivitydetail">The YammerGroupsActivityDetail object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetYammerGroupsActivityDetailCollectionPage> PatchAsync(YammerGroupsActivityDetail yammergroupsactivitydetail, 
+        public async System.Threading.Tasks.Task<IReportRootGetYammerGroupsActivityDetailCollectionPage> PatchAsync(YammerGroupsActivityDetail yammergroupsactivitydetail,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="yammergroupsactivitydetail">The YammerGroupsActivityDetail object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetYammerGroupsActivityDetailCollectionPage> PutAsync(YammerGroupsActivityDetail yammergroupsactivitydetail, 
+        public async System.Threading.Tasks.Task<IReportRootGetYammerGroupsActivityDetailCollectionPage> PutAsync(YammerGroupsActivityDetail yammergroupsactivitydetail,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetYammerGroupsActivityGroupCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetYammerGroupsActivityGroupCountsRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="yammergroupsactivitygroupcounts">The YammerGroupsActivityGroupCounts object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetYammerGroupsActivityGroupCountsCollectionPage> PatchAsync(YammerGroupsActivityGroupCounts yammergroupsactivitygroupcounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetYammerGroupsActivityGroupCountsCollectionPage> PatchAsync(YammerGroupsActivityGroupCounts yammergroupsactivitygroupcounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="yammergroupsactivitygroupcounts">The YammerGroupsActivityGroupCounts object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<IReportRootGetYammerGroupsActivityGroupCountsCollectionPage> PutAsync(YammerGroupsActivityGroupCounts yammergroupsactivitygroupcounts, 
+        public async System.Threading.Tasks.Task<IReportRootGetYammerGroupsActivityGroupCountsCollectionPage> PutAsync(YammerGroupsActivityGroupCounts yammergroupsactivitygroupcounts,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootManagedDeviceEnrollmentAbandonmentDetailsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootManagedDeviceEnrollmentAbandonmentDetailsRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootManagedDeviceEnrollmentAbandonmentSummaryRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootManagedDeviceEnrollmentAbandonmentSummaryRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootManagedDeviceEnrollmentFailureTrendsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootManagedDeviceEnrollmentFailureTrendsRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/SiteGetApplicableContentTypesForListRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/SiteGetApplicableContentTypesForListRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Graph
         /// <param name="contenttype">The ContentType object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<ISiteGetApplicableContentTypesForListCollectionPage> PatchAsync(ContentType contenttype, 
+        public async System.Threading.Tasks.Task<ISiteGetApplicableContentTypesForListCollectionPage> PatchAsync(ContentType contenttype,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -132,7 +132,7 @@ namespace Microsoft.Graph
         /// <param name="contenttype">The ContentType object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public async System.Threading.Tasks.Task<ISiteGetApplicableContentTypesForListCollectionPage> PutAsync(ContentType contenttype, 
+        public async System.Threading.Tasks.Task<ISiteGetApplicableContentTypesForListCollectionPage> PutAsync(ContentType contenttype,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/SiteGetByPathRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/SiteGetByPathRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="site">The Site object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Site> PatchAsync(Site site, 
+        public System.Threading.Tasks.Task<Site> PatchAsync(Site site,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="site">The Site object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Site> PutAsync(Site site, 
+        public System.Threading.Tasks.Task<Site> PutAsync(Site site,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/UserExperienceAnalyticsRegressionSummarySummarizeDeviceRegressionPerformanceRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/UserExperienceAnalyticsRegressionSummarySummarizeDeviceRegressionPerformanceRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="userexperienceanalyticsregressionsummary">The UserExperienceAnalyticsRegressionSummary object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<UserExperienceAnalyticsRegressionSummary> PatchAsync(UserExperienceAnalyticsRegressionSummary userexperienceanalyticsregressionsummary, 
+        public System.Threading.Tasks.Task<UserExperienceAnalyticsRegressionSummary> PatchAsync(UserExperienceAnalyticsRegressionSummary userexperienceanalyticsregressionsummary,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="userexperienceanalyticsregressionsummary">The UserExperienceAnalyticsRegressionSummary object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<UserExperienceAnalyticsRegressionSummary> PutAsync(UserExperienceAnalyticsRegressionSummary userexperienceanalyticsregressionsummary, 
+        public System.Threading.Tasks.Task<UserExperienceAnalyticsRegressionSummary> PutAsync(UserExperienceAnalyticsRegressionSummary userexperienceanalyticsregressionsummary,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/UserExportDeviceAndAppManagementDataRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/UserExportDeviceAndAppManagementDataRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="deviceandappmanagementdata">The DeviceAndAppManagementData object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<DeviceAndAppManagementData> PatchAsync(DeviceAndAppManagementData deviceandappmanagementdata, 
+        public System.Threading.Tasks.Task<DeviceAndAppManagementData> PatchAsync(DeviceAndAppManagementData deviceandappmanagementdata,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="deviceandappmanagementdata">The DeviceAndAppManagementData object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<DeviceAndAppManagementData> PutAsync(DeviceAndAppManagementData deviceandappmanagementdata, 
+        public System.Threading.Tasks.Task<DeviceAndAppManagementData> PutAsync(DeviceAndAppManagementData deviceandappmanagementdata,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookChartItemAtRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookChartItemAtRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookchart">The WorkbookChart object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookChart> PatchAsync(WorkbookChart workbookchart, 
+        public System.Threading.Tasks.Task<WorkbookChart> PatchAsync(WorkbookChart workbookchart,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookchart">The WorkbookChart object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookChart> PutAsync(WorkbookChart workbookchart, 
+        public System.Threading.Tasks.Task<WorkbookChart> PutAsync(WorkbookChart workbookchart,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookChartItemRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookChartItemRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookchart">The WorkbookChart object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookChart> PatchAsync(WorkbookChart workbookchart, 
+        public System.Threading.Tasks.Task<WorkbookChart> PatchAsync(WorkbookChart workbookchart,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookchart">The WorkbookChart object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookChart> PutAsync(WorkbookChart workbookchart, 
+        public System.Threading.Tasks.Task<WorkbookChart> PutAsync(WorkbookChart workbookchart,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookChartPointItemAtRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookChartPointItemAtRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookchartpoint">The WorkbookChartPoint object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookChartPoint> PatchAsync(WorkbookChartPoint workbookchartpoint, 
+        public System.Threading.Tasks.Task<WorkbookChartPoint> PatchAsync(WorkbookChartPoint workbookchartpoint,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookchartpoint">The WorkbookChartPoint object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookChartPoint> PutAsync(WorkbookChartPoint workbookchartpoint, 
+        public System.Threading.Tasks.Task<WorkbookChartPoint> PutAsync(WorkbookChartPoint workbookchartpoint,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookChartSeriesItemAtRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookChartSeriesItemAtRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookchartseries">The WorkbookChartSeries object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookChartSeries> PatchAsync(WorkbookChartSeries workbookchartseries, 
+        public System.Threading.Tasks.Task<WorkbookChartSeries> PatchAsync(WorkbookChartSeries workbookchartseries,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookchartseries">The WorkbookChartSeries object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookChartSeries> PutAsync(WorkbookChartSeries workbookchartseries, 
+        public System.Threading.Tasks.Task<WorkbookChartSeries> PutAsync(WorkbookChartSeries workbookchartseries,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookNamedItemRangeRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookNamedItemRangeRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookRangeBorderItemAtRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookRangeBorderItemAtRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrangeborder">The WorkbookRangeBorder object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRangeBorder> PatchAsync(WorkbookRangeBorder workbookrangeborder, 
+        public System.Threading.Tasks.Task<WorkbookRangeBorder> PatchAsync(WorkbookRangeBorder workbookrangeborder,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrangeborder">The WorkbookRangeBorder object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRangeBorder> PutAsync(WorkbookRangeBorder workbookrangeborder, 
+        public System.Threading.Tasks.Task<WorkbookRangeBorder> PutAsync(WorkbookRangeBorder workbookrangeborder,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookRangeBoundingRectRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookRangeBoundingRectRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookRangeCellRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookRangeCellRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookRangeColumnRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookRangeColumnRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookRangeColumnsAfterRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookRangeColumnsAfterRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookRangeColumnsBeforeRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookRangeColumnsBeforeRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookRangeEntireColumnRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookRangeEntireColumnRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookRangeEntireRowRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookRangeEntireRowRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookRangeIntersectionRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookRangeIntersectionRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookRangeLastCellRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookRangeLastCellRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookRangeLastColumnRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookRangeLastColumnRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookRangeLastRowRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookRangeLastRowRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookRangeOffsetRangeRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookRangeOffsetRangeRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookRangeResizedRangeRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookRangeResizedRangeRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookRangeRowRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookRangeRowRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookRangeRowsAboveRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookRangeRowsAboveRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookRangeRowsBelowRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookRangeRowsBelowRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookRangeUsedRangeRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookRangeUsedRangeRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookRangeViewItemAtRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookRangeViewItemAtRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrangeview">The WorkbookRangeView object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRangeView> PatchAsync(WorkbookRangeView workbookrangeview, 
+        public System.Threading.Tasks.Task<WorkbookRangeView> PatchAsync(WorkbookRangeView workbookrangeview,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrangeview">The WorkbookRangeView object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRangeView> PutAsync(WorkbookRangeView workbookrangeview, 
+        public System.Threading.Tasks.Task<WorkbookRangeView> PutAsync(WorkbookRangeView workbookrangeview,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookRangeViewRangeRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookRangeViewRangeRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookRangeVisibleViewRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookRangeVisibleViewRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrangeview">The WorkbookRangeView object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRangeView> PatchAsync(WorkbookRangeView workbookrangeview, 
+        public System.Threading.Tasks.Task<WorkbookRangeView> PatchAsync(WorkbookRangeView workbookrangeview,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrangeview">The WorkbookRangeView object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRangeView> PutAsync(WorkbookRangeView workbookrangeview, 
+        public System.Threading.Tasks.Task<WorkbookRangeView> PutAsync(WorkbookRangeView workbookrangeview,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookTableColumnDataBodyRangeRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookTableColumnDataBodyRangeRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookTableColumnHeaderRowRangeRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookTableColumnHeaderRowRangeRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookTableColumnItemAtRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookTableColumnItemAtRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbooktablecolumn">The WorkbookTableColumn object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookTableColumn> PatchAsync(WorkbookTableColumn workbooktablecolumn, 
+        public System.Threading.Tasks.Task<WorkbookTableColumn> PatchAsync(WorkbookTableColumn workbooktablecolumn,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbooktablecolumn">The WorkbookTableColumn object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookTableColumn> PutAsync(WorkbookTableColumn workbooktablecolumn, 
+        public System.Threading.Tasks.Task<WorkbookTableColumn> PutAsync(WorkbookTableColumn workbooktablecolumn,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookTableColumnRangeRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookTableColumnRangeRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookTableColumnTotalRowRangeRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookTableColumnTotalRowRangeRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookTableDataBodyRangeRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookTableDataBodyRangeRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookTableHeaderRowRangeRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookTableHeaderRowRangeRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookTableItemAtRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookTableItemAtRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbooktable">The WorkbookTable object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookTable> PatchAsync(WorkbookTable workbooktable, 
+        public System.Threading.Tasks.Task<WorkbookTable> PatchAsync(WorkbookTable workbooktable,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbooktable">The WorkbookTable object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookTable> PutAsync(WorkbookTable workbooktable, 
+        public System.Threading.Tasks.Task<WorkbookTable> PutAsync(WorkbookTable workbooktable,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookTableRangeRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookTableRangeRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookTableRowItemAtRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookTableRowItemAtRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbooktablerow">The WorkbookTableRow object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookTableRow> PatchAsync(WorkbookTableRow workbooktablerow, 
+        public System.Threading.Tasks.Task<WorkbookTableRow> PatchAsync(WorkbookTableRow workbooktablerow,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbooktablerow">The WorkbookTableRow object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookTableRow> PutAsync(WorkbookTableRow workbooktablerow, 
+        public System.Threading.Tasks.Task<WorkbookTableRow> PutAsync(WorkbookTableRow workbooktablerow,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookTableRowRangeRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookTableRowRangeRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookTableTotalRowRangeRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookTableTotalRowRangeRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookWorksheetCellRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookWorksheetCellRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookWorksheetRangeRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookWorksheetRangeRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookWorksheetUsedRangeRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookWorksheetUsedRangeRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/tests/Microsoft.Graph.DotnetCore.Test/Models/ModelSerializationTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Test/Models/ModelSerializationTests.cs
@@ -3,6 +3,7 @@
 // ------------------------------------------------------------------------------
 
 using Microsoft.Graph;
+using Microsoft.Graph.Ediscovery;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -171,5 +172,29 @@ namespace Microsoft.Graph.DotnetCore.Test.Models
 
             Assert.Equal(expectedSerializedString, serializedString);
         }
+
+        [Fact]
+        public void SerializeDerivedTypeProperty()
+        {
+            // Arrange
+            NoncustodialDataSource ncds = new NoncustodialDataSource()
+            {
+                ApplyHoldToSource = true,
+                DataSource = new UserSource()
+                {
+                    Email = "jewell@ediscodemo.onmicrosoft.com"
+                }
+            };
+            // The email property should exist even though it the property of a derived type.
+            var expectedString = @"{""applyHoldToSource"":true,""dataSource"":{""email"":""jewell@ediscodemo.onmicrosoft.com"",""@odata.type"":""microsoft.graph.ediscovery.userSource""},""@odata.type"":""microsoft.graph.ediscovery.noncustodialDataSource""}";
+            
+            // Act
+            var serializedString = this.serializer.SerializeObject(ncds);
+
+            // Assert
+            Assert.Equal(expectedString,serializedString);
+
+        }
+
     }
 }


### PR DESCRIPTION
This PR closes https://github.com/microsoftgraph/msgraph-beta-sdk-dotnet/issues/262

It fixes the issue where abstract types that have a base type not being annotated with the DeriveTypeConverter attribute.

This is a problem in System.Text.Json serialization as it causes derived types to be serialized only with the base type property as  System.Text.Json does not fully support polymorphic serialization like Newtonsoft.Json.
