### PR TITLE
Debug Symbols support on feature/2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The Microsoft Graph Beta .NET Client Library targets .NetStandard 1.1 and .Net F
 To install the client library via NuGet:
 
 * Search for `Microsoft.Graph.Beta` in the NuGet Library, or
-* Type `Install-Package Microsoft.Graph.Beta` into the Package Manager Console.
+* Type `Install-Package Microsoft.Graph.Beta -PreRelease` into the Package Manager Console.
 
 ## Using the beta client along with the v1.0 library
 

--- a/pipelines/ci-build.yml
+++ b/pipelines/ci-build.yml
@@ -1,0 +1,185 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+name: $(BuildDefinitionName)_$(SourceBranchName)_$(Date:yyyyMMdd)$(Rev:.r)
+trigger:
+  branches:
+    include:
+      - master
+
+pool:
+  vmImage: 'windows-latest'
+
+variables:
+  BuildConfiguration: 'release'
+
+steps:
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@2
+  displayName: 'Run CredScan'
+  inputs:
+    debugMode: false
+
+- task: DotNetCoreCLI@2
+  displayName: 'dotnet restore'
+  inputs:
+    command: restore
+    projects: '**/*.csproj'
+
+- powershell: |
+   # This allows us to not have to checkin .csproj files with DelaySign and SignAssembly set to to true. If the flag is set,
+   # then project is not debuggable with SignAssembly set to true.
+   # Assumption: working directory is /src/
+
+   $csprojPaths = @(".\Microsoft.Graph\Microsoft.Graph.Beta.csproj")
+
+   foreach ($csprojPath in $csprojPaths) {
+
+       $doc = New-Object System.Xml.XmlDocument
+       $doc.Load($csprojPath)
+
+       # Set the DelaySign element to 'true' so that delay signing is set.
+       $delaySign = $doc.SelectSingleNode("//DelaySign");
+       $delaySign.'#text'= "true"
+
+       # Set the SignAssembly element to 'true' so that we can sign the assemblies.
+       $signAssembly = $doc.SelectSingleNode("//SignAssembly");
+       $signAssembly.'#text'= "true"
+
+       $doc.Save($csprojPath);
+   }
+
+   Write-Host "Updated the .csproj files so that we can sign the built assemblies."
+  workingDirectory: src
+  displayName: 'Set project ready to sign'
+
+- task: DotNetCoreCLI@2
+  displayName: 'dotnet build'
+  inputs:
+    projects: '$(Build.SourcesDirectory)\src\Microsoft.Graph\Microsoft.Graph.Beta.csproj'
+    arguments: '-c $(BuildConfiguration) --no-incremental'
+
+- task: DotNetCoreCLI@2
+  displayName: 'run tests'
+  inputs:
+    command: 'test'
+    projects: 'tests/Microsoft.Graph.DotnetCore.Test/Microsoft.Graph.DotnetCore.Test.csproj'
+    arguments: '--configuration $(BuildConfiguration) --verbosity normal'
+
+- task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+  displayName: 'ESRP DLL Strong Name (Microsoft.Graph.Beta)'
+  inputs:
+    ConnectedServiceName: 'microsoftgraph ESRP CodeSign DLL and NuGet (AKV)'
+    FolderPath: src/Microsoft.Graph/bin/release
+    Pattern: Microsoft.Graph.Beta.dll
+    signConfigType: inlineSignParams
+    inlineOperation: |
+     [
+         {
+             "keyCode": "CP-233863-SN",
+             "operationSetCode": "StrongNameSign",
+             "parameters": [],
+             "toolName": "sign",
+             "toolVersion": "1.0"
+         },
+         {
+             "keyCode": "CP-233863-SN",
+             "operationSetCode": "StrongNameVerify",
+             "parameters": [],
+             "toolName": "sign",
+             "toolVersion": "1.0"
+         }
+     ]
+    SessionTimeout: 20
+
+- task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+  displayName: 'ESRP DLL CodeSigning (Microsoft.Graph.Beta)'
+  inputs:
+    ConnectedServiceName: 'microsoftgraph ESRP CodeSign DLL and NuGet (AKV)'
+    FolderPath: src/Microsoft.Graph/bin/release
+    Pattern: Microsoft.Graph.Beta.dll
+    signConfigType: inlineSignParams
+    inlineOperation: |
+     [
+         {
+             "keyCode": "CP-230012",
+             "operationSetCode": "SigntoolSign",
+             "parameters": [
+                 {
+                     "parameterName": "OpusName",
+                     "parameterValue": "Microsoft"
+                 },
+                 {
+                     "parameterName": "OpusInfo",
+                     "parameterValue": "http://www.microsoft.com"
+                 },
+                 {
+                     "parameterName": "FileDigest",
+                     "parameterValue": "/fd \"SHA256\""
+                 },
+                 {
+                     "parameterName": "PageHash",
+                     "parameterValue": "/NPH"
+                 },
+                 {
+                     "parameterName": "TimeStamp",
+                     "parameterValue": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+                 }
+             ],
+             "toolName": "sign",
+             "toolVersion": "1.0"
+         },
+         {
+             "keyCode": "CP-230012",
+             "operationSetCode": "SigntoolVerify",
+             "parameters": [],
+             "toolName": "sign",
+             "toolVersion": "1.0"
+         }
+     ]
+    SessionTimeout: 20
+
+# arguments are not parsed in DotNetCoreCLI@2 task for `pack` command, that's why we have a custom pack command here
+- powershell: |
+    dotnet pack $env:BUILD_SOURCESDIRECTORY/src/Microsoft.Graph/Microsoft.Graph.Beta.csproj /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg --no-build --output $env:BUILD_ARTIFACTSTAGINGDIRECTORY --configuration $env:BUILD_CONFIGURATION
+  env:
+    BUILD_CONFIGURATION: $(BuildConfiguration)
+  displayName: 'dotnet pack'
+
+- task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+  displayName: 'ESRP NuGet CodeSigning'
+  inputs:
+    ConnectedServiceName: 'microsoftgraph ESRP CodeSign DLL and NuGet (AKV)'
+    FolderPath: '$(Build.ArtifactStagingDirectory)'
+    Pattern: '*nupkg'
+    signConfigType: inlineSignParams
+    inlineOperation: |
+          [
+              {
+                  "keyCode": "CP-401405",
+                  "operationSetCode": "NuGetSign",
+                  "parameters": [ ],
+                  "toolName": "sign",
+                  "toolVersion": "1.0"
+              },
+              {
+                  "keyCode": "CP-401405",
+                  "operationSetCode": "NuGetVerify",
+                  "parameters": [ ],
+                  "toolName": "sign",
+                  "toolVersion": "1.0"
+              }
+          ]
+
+    SessionTimeout: 20
+
+- task: CopyFiles@2
+  displayName: 'Copy release scripts to artifact staging directory'
+  inputs:
+    SourceFolder: '$(Build.SourcesDirectory)'
+    Contents: 'scripts\**'
+    TargetFolder: '$(Build.ArtifactStagingDirectory) '
+
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish Artifact: Microsoft.Graph.Beta.nupkg and release pipeline scripts'
+
+#Task group has not been exported, task groups are not supported yet

--- a/pipelines/ci-build.yml
+++ b/pipelines/ci-build.yml
@@ -6,6 +6,7 @@ trigger:
   branches:
     include:
       - master
+pr: none
 
 pool:
   vmImage: 'windows-latest'

--- a/scripts/GetNugetPackageVersion.ps1
+++ b/scripts/GetNugetPackageVersion.ps1
@@ -21,12 +21,20 @@ Param(
 
 Write-Host "Get the NuGet package version and set it in the global variable: VERSION_STRING" -ForegroundColor Magenta
 
-$nugetPackageName = (Get-ChildItem $packageDirPath | Where Name -match Microsoft.Graph.Beta).Name
+$nugetPackageName = (Get-ChildItem (Join-Path $packageDirPath *.nupkg) -Exclude *.symbols.nupkg).Name
 
 Write-Host "Found NuGet package: $nugetPackageName" -ForegroundColor Magenta
+$packageVersionRegex = "Microsoft\.Graph\.Beta\.([0-9]+\.[0-9]+\.[0-9]+-\w+)\.nupkg"
 
 ## Extracts the package version from nupkg file name.
-$packageVersion = $nugetPackageName -replace "^(.*?)\.((?:\.?[0-9]+){3,}(?:[-a-z]+)?)\.nupkg$", '$2'
-
-Write-Host "##vso[task.setvariable variable=VERSION_STRING]$($packageVersion)";
-Write-Host "Updated the VERSION_STRING environment variable with the package version value '$packageVersion'." -ForegroundColor Green
+if ($nugetPackageName -match $packageVersionRegex)
+{
+    $packageVersion = $Matches[1]
+    Write-Host "##vso[task.setvariable variable=VERSION_STRING]$($packageVersion)";
+    Write-Host "Updated the VERSION_STRING environment variable with the package version value '$packageVersion'." -ForegroundColor Green
+}
+else
+{
+    Write-Host "Regular expression used in extracting the package version is: $packageVersionRegex"
+    Write-Error "We can't extract package version from the string"
+}

--- a/src/Microsoft.Graph/Microsoft.Graph.Beta.csproj
+++ b/src/Microsoft.Graph/Microsoft.Graph.Beta.csproj
@@ -54,7 +54,7 @@
     <None Include=".\..\..\LICENSE.txt" Pack="true" PackagePath="" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Graph.Core" Version="2.0.0-preview.8" />
+    <PackageReference Include="Microsoft.Graph.Core" Version="2.0.0-preview.9" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">

--- a/src/Microsoft.Graph/Microsoft.Graph.Beta.csproj
+++ b/src/Microsoft.Graph/Microsoft.Graph.Beta.csproj
@@ -27,6 +27,7 @@
 - [Breaking change] Removed IGraphServiceClient interface
 - Added GraphServiceClient constructor that accepts TokenCredential instance
 - [Breaking change] Bump minimun .NetFramework version to 4.6.2 from 4.6.1
+- Add source link to the nuget package.
     </PackageReleaseNotes>
     <!-- edit this value to change the current major.minor.patch version -->
     <VersionPrefix>4.0.0</VersionPrefix>
@@ -36,16 +37,24 @@
     <!-- $(Prerelease).$(BUILD_BUILDID) -->
     <!-- <VersionSuffix Condition=" '$(Prerelease)' != '' ">$(Prerelease)</VersionSuffix> -->
     <VersionSuffix>preview.2</VersionSuffix>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <Deterministic>true</Deterministic>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">
     <DocumentationFile>bin\Release\Microsoft.Graph.Beta.xml</DocumentationFile>
     <NoWarn>1701;1702;1705;1591</NoWarn>
+  </PropertyGroup>
+  <!-- https://github.com/clairernovotny/DeterministicBuilds#deterministic-builds -->
+  <PropertyGroup Condition="'$(TF_BUILD)' == 'true'">
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>
   <ItemGroup>
     <None Include=".\..\..\LICENSE.txt" Pack="true" PackagePath="" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Graph.Core" Version="2.0.0-preview.8" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
     <Reference Include="System" />

--- a/src/Microsoft.Graph/Microsoft.Graph.Beta.csproj
+++ b/src/Microsoft.Graph/Microsoft.Graph.Beta.csproj
@@ -28,6 +28,7 @@
 - Added GraphServiceClient constructor that accepts TokenCredential instance
 - [Breaking change] Bump minimun .NetFramework version to 4.6.2 from 4.6.1
 - Add source link to the nuget package.
+- Uses snupkg as symbol file.
     </PackageReleaseNotes>
     <!-- edit this value to change the current major.minor.patch version -->
     <VersionPrefix>4.0.0</VersionPrefix>


### PR DESCRIPTION
This PR synchronizes the following PRs with the 2.0 branch to bring debug symbols support

#247 - Add source link to enable debugging of our NuGet package
#249 - fix version inference from .nupkg package
#251 - Migrate release build definition and build snupkg files as part of the pipeline
#259 - Fix prerelease instruction

Artifacts produced for this PR/branch can be found [here](https://o365exchange.visualstudio.com/O365%20Sandbox/_build/results?buildId=5003642&view=results).

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-beta-sdk-dotnet/pull/271)