### PR TITLE
Enable custom base address with httpclient constructor

### DIFF
--- a/src/Microsoft.Graph/Generated/requests/GraphServiceClient.cs
+++ b/src/Microsoft.Graph/Generated/requests/GraphServiceClient.cs
@@ -64,9 +64,11 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="httpClient">The <see cref="HttpClient"/> to use for making requests to Microsoft Graph. Use the <see cref="GraphClientFactory"/>
         /// to get a pre-configured HttpClient that is optimized for use with the Microsoft Graph service API. </param>
+        /// <param name="baseUrl">The base service URL. For example, "https://graph.microsoft.com/beta".</param>
         public GraphServiceClient(
-            HttpClient httpClient)
-            : base("https://graph.microsoft.com/beta", httpClient)
+            HttpClient httpClient,
+            string baseUrl = "https://graph.microsoft.com/beta")
+            : base(baseUrl, httpClient)
         {
         }
     


### PR DESCRIPTION
This PR closes https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/916.

It enables the users of the SDK to define their own base address for the requestbuilders in the event they are using their own httpclient and varying clouds.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-beta-sdk-dotnet/pull/276)