### PR TITLE
Revert "Bump Microsoft.SourceLink.GitHub from 1.0.0 to 1.1.0"

### DIFF
--- a/src/Microsoft.Graph/Microsoft.Graph.Beta.csproj
+++ b/src/Microsoft.Graph/Microsoft.Graph.Beta.csproj
@@ -55,7 +55,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Graph.Core" Version="2.*" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
     <Reference Include="System" />


### PR DESCRIPTION
Reverts microsoftgraph/msgraph-beta-sdk-dotnet#372 as this is causing issues on the release pipeline. 

Related to upstream issue at https://github.com/dotnet/sourcelink/issues/768 and will merge back in once issue is resolved

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-beta-sdk-dotnet/pull/373)