### PR TITLE
Use dotnet 6 in ci-build.yml

### DIFF
--- a/pipelines/ci-build.yml
+++ b/pipelines/ci-build.yml
@@ -15,6 +15,18 @@ variables:
   BuildConfiguration: 'release'
 
 steps:
+- task: UseDotNet@2
+  displayName: 'Use .NET sdk'
+  inputs:
+    packageType: sdk
+    version: 6.x
+
+- task: UseDotNet@2
+  displayName: 'Use .NET 2.x (for code signing tasks)'
+  inputs:
+    packageType: sdk
+    version: 2.x
+
 - task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@2
   displayName: 'Run CredScan'
   inputs:


### PR DESCRIPTION
This PR uses the dotnet 6 as the installed sdk to resolve build issues detected on the release pipeline as outlined in #373 

We also install dotnet core version 2.x as the ESRP tasks need it for code signing.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-beta-sdk-dotnet/pull/374)