### PR TITLE
- updates target for test project to unblock beta generation

### DIFF
--- a/tests/Microsoft.Graph.DotnetCore.Test/Microsoft.Graph.DotnetCore.Test.csproj
+++ b/tests/Microsoft.Graph.DotnetCore.Test/Microsoft.Graph.DotnetCore.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <TargetLatestRuntimePatch>false</TargetLatestRuntimePatch>
     <AssemblyName>Microsoft.Graph.DotnetCore.Test</AssemblyName>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>


### PR DESCRIPTION
The [v1 test project](https://github.com/microsoftgraph/msgraph-sdk-dotnet/blob/dev/tests/Microsoft.Graph.DotnetCore.Test/Microsoft.Graph.DotnetCore.Test.csproj) targets 3.1
The current target [makes the generation fail](https://microsoftgraph.visualstudio.com/Graph%20Developer%20Experiences/_build/results?buildId=60847&view=logs&j=75842713-d241-5c51-b0b4-a337631cec97&t=c3da5ce4-958d-57ba-561a-54d688869703) after the upgrade of the pipeline to net 6.0

This PR aims to solve that.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-beta-sdk-dotnet/pull/380)