### PR TITLE
Task disambiguation #2

### DIFF
--- a/tests/Microsoft.Graph.DotnetCore.Test/Mocks/MockHttpProvider.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Test/Mocks/MockHttpProvider.cs
@@ -4,7 +4,6 @@
 
 using Moq;
 using System.Net.Http;
-using System.Threading.Tasks;
 
 namespace Microsoft.Graph.DotnetCore.Core.Test.Mocks
 {
@@ -17,7 +16,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Mocks
 
             this.Setup(
                 provider => provider.SendAsync(It.IsAny<HttpRequestMessage>()))
-                .Returns(Task.FromResult(httpResponseMessage));
+                .Returns(System.Threading.Tasks.Task.FromResult(httpResponseMessage));
 
             this.SetupGet(provider => provider.Serializer).Returns(serializer);
         }

--- a/tests/Microsoft.Graph.DotnetCore.Test/Mocks/MockRedirctHandler.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Test/Mocks/MockRedirctHandler.cs
@@ -4,7 +4,6 @@
 
 using System.Net.Http;
 using System.Threading;
-using System.Threading.Tasks;
 
 namespace Microsoft.Graph.DotnetCore.Core.Test.Mocks
 {
@@ -17,19 +16,19 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Mocks
 
         private bool _response1Sent = false;
 
-        protected async override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        protected async override System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             if (!_response1Sent)
             {
                 _response1Sent = true;
                 _response1.RequestMessage = request;
-                return await Task.FromResult(_response1);
+                return await System.Threading.Tasks.Task.FromResult(_response1);
             }
             else
             {
                 _response1Sent = false;
                 _response2.RequestMessage = request;
-                return await Task.FromResult(_response2);
+                return await System.Threading.Tasks.Task.FromResult(_response2);
             }
         }
 

--- a/tests/Microsoft.Graph.DotnetCore.Test/Mocks/TestHttpMessageHandler.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Test/Mocks/TestHttpMessageHandler.cs
@@ -5,7 +5,6 @@
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading;
-using System.Threading.Tasks;
 
 namespace Microsoft.Graph.DotnetCore.Core.Test.Mocks
 {
@@ -23,17 +22,17 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Mocks
             this.responseMessages.Add(requestUrl, responseMessage);
         }
 
-        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        protected override System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             HttpResponseMessage responseMessage;
 
             if (this.responseMessages.TryGetValue(request.RequestUri.ToString(), out responseMessage))
             {
                 responseMessage.RequestMessage = request;
-                return Task.FromResult(responseMessage);
+                return System.Threading.Tasks.Task.FromResult(responseMessage);
             }
 
-            return Task.FromResult<HttpResponseMessage>(null);
+            return System.Threading.Tasks.Task.FromResult<HttpResponseMessage>(null);
         }
     }
 }


### PR DESCRIPTION
This PR is related to https://github.com/microsoftgraph/msgraph-sdk-dotnet/pull/1194

It unblocks generation by applying similar changes reported in the PR above.

**Failing build** 
https://dev.azure.com/microsoftgraph/Graph%20Developer%20Experiences/_build/results?buildId=61672&view=logs&j=4c81e8e4-6eb9-5def-7261-b44ad0fc1b7d&t=d7256970-5877-5148-923c-bfd9787d6286
###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-beta-sdk-dotnet/pull/383)