### PR TITLE
Fixes regression on passing custom baseurl (beta)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project does NOT adhere to [Semantic Versioning](https://semver.org/spe
 
 ## [Unreleased]
 
+## [5.16.1-preview] - 2023-01-16
+
+### Changed
+
+- Fixed a regression where passing custom base url would not be reflected in the requests.
+
 ## [5.16.0-preview] - 2023-01-11
 
 ### Changed

--- a/src/Microsoft.Graph/GraphServiceClient.cs
+++ b/src/Microsoft.Graph/GraphServiceClient.cs
@@ -33,12 +33,9 @@ namespace Microsoft.Graph.Beta
         /// </summary>
         /// <param name="requestAdapter">The custom <see cref="IRequestAdapter"/> to be used for making requests</param>
         /// <param name="baseUrl">The base service URL. For example, "https://graph.microsoft.com/beta"</param>
-        public GraphServiceClient(IRequestAdapter requestAdapter, string baseUrl = null): base(requestAdapter)
+        public GraphServiceClient(IRequestAdapter requestAdapter, string baseUrl = null): base(InitializeRequestAdapterWithBaseUrl(requestAdapter,baseUrl))
         {
             this.RequestAdapter = requestAdapter;
-            if (!string.IsNullOrEmpty(baseUrl)) {
-                this.RequestAdapter.BaseUrl = baseUrl;
-            }
         }
 
         /// <summary>
@@ -95,6 +92,16 @@ namespace Microsoft.Graph.Beta
             {
                 return new BatchRequestBuilder(this.RequestAdapter);
             }
+        }
+        
+        private static IRequestAdapter InitializeRequestAdapterWithBaseUrl(IRequestAdapter requestAdapter, string baseUrl)
+        {
+            if (!string.IsNullOrEmpty(baseUrl))
+            {
+                requestAdapter.BaseUrl = baseUrl;
+            }
+
+            return requestAdapter;
         }
     }
 }

--- a/src/Microsoft.Graph/Microsoft.Graph.Beta.csproj
+++ b/src/Microsoft.Graph/Microsoft.Graph.Beta.csproj
@@ -22,12 +22,10 @@
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <PackageReleaseNotes>
-- [Breaking] Renames `CreateXXXRequestInformation` methods to `ToXXXRequestInformation
-- Adds `IAuthenticationProvider` parameter to GraphServiceClient constructor taking a httpClient instance.
-- Latest metadata updates from 12th January 2023 snapshot
+- Fixed a regression where passing custom base url would not be reflected in the requests.
     </PackageReleaseNotes>
     <!-- edit this value to change the current major.minor.patch version -->
-    <VersionPrefix>5.16.0</VersionPrefix>
+    <VersionPrefix>5.16.1</VersionPrefix>
     <!-- adds a version suffix if the Prerelease environment variable is set. BUILD_BUILDID is an
     environment variable set by Azure pipelines from the build. We can use the buildid to correlate
     which commit was used to generate the preview build. -->

--- a/tests/Microsoft.Graph.DotnetCore.Test/Models/GraphServiceClientTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Test/Models/GraphServiceClientTests.cs
@@ -1,0 +1,39 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+using Microsoft.Graph.Beta;
+using Microsoft.Kiota.Abstractions.Authentication;
+using Xunit;
+
+namespace Microsoft.Graph.DotnetCore.Test.Models;
+
+public class GraphServiceClientTests
+{
+    [Fact]
+    public void InitializesClient()
+    {
+        // Arrange
+        var graphClient = new GraphServiceClient(new AnonymousAuthenticationProvider());
+        
+        // Act
+        var userRequestInformation = graphClient.Me.ToGetRequestInformation();
+        
+        // Assert
+        Assert.Contains("https://graph.microsoft.com", userRequestInformation.URI.OriginalString);
+    }
+    
+    [Fact]
+    public void InitializesClientWithCustomBaseUrl()
+    {
+        // Arrange
+        var customBaseUrl = "https://graph.microsoft-ppe.com";
+        var graphClient = new GraphServiceClient(new AnonymousAuthenticationProvider(), customBaseUrl);
+        
+        // Act
+        var userRequestInformation = graphClient.Me.ToGetRequestInformation();
+        
+        // Assert
+        Assert.Contains(customBaseUrl, userRequestInformation.URI.OriginalString);
+    }
+}


### PR DESCRIPTION
This PR closes https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/1613

It addresses a regression introduced by adding the baseurl to the `PathParameters` collection of the GraphServiceClient that prevented the correct propagation of custom base urls passed to the constructor. 
This PR therefore ensures the `RequestAdapter` is properly initialized with the custom base url to ensure the correct url is passed to the PathParameters collection.