### PR TITLE
- add branch protection policy file

### DIFF
--- a/.github/policies/msgraph-beta-sdk-dotnet-branch-protection.yml
+++ b/.github/policies/msgraph-beta-sdk-dotnet-branch-protection.yml
@@ -25,11 +25,14 @@ configuration:
     requireCodeOwnersReview: true
     # Are commits required to be signed. boolean
     requiresCommitSignatures: false
+    # Are conversations required to be resolved before merging? boolean
+    requiresConversationResolution: true
     # Are merge commits prohibited from being pushed to this branch. boolean
     requiresLinearHistory: false
     # Requires requiresStrictStatusChecks. Values can be any string, but if the value does not correspond to any existing status check, the status check will be stuck on pending for status since nothing exists to push an actual status
     requiredStatusChecks:
     - build
+    - license/cla
     # The docs conflict. Are branches required to be up to date before merging. Or Require status checks to pass before merging
     requiresStrictStatusChecks: true
     # Restrict who can push to matching branches

--- a/.github/policies/msgraph-beta-sdk-dotnet-branch-protection.yml
+++ b/.github/policies/msgraph-beta-sdk-dotnet-branch-protection.yml
@@ -1,0 +1,65 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# File initially created using https://github.com/MIchaelMainer/policyservicetoolkit/blob/main/branch_protection_export.ps1.
+
+name: msgraph-beta-sdk-dotnet-branch-protection
+description: Branch protection policy for the msgraph-beta-sdk-dotnet repository
+resource: repository
+configuration:
+  branchProtectionRules:
+
+  # The following GitHub PolicyService properties are not supported: whoCanDismissReviews and whoCanPush
+  - branchNamePattern: master
+    # Specifies whether this branch can be deleted. boolean
+    allowsDeletions: false
+    # Specifies whether forced pushes are allowed on this branch. boolean
+    allowsForcePushes: false
+    # Specifies whether new commits pushed to the matching branches dismiss pull request review approvals. boolean
+    dismissStaleReviews: false
+    # Specifies whether admins can overwrite branch protection. boolean
+    isAdminEnforced: false
+    # Specifies the number of pull request reviews before merging. int (0-6)
+    requiredApprovingReviewsCount: 1
+    # Require review from Code Owners. Requires requiredApprovingReviewsCount. boolean
+    requireCodeOwnersReview: true
+    # Are commits required to be signed. boolean
+    requiresCommitSignatures: false
+    # Are merge commits prohibited from being pushed to this branch. boolean
+    requiresLinearHistory: false
+    # Requires requiresStrictStatusChecks. Values can be any string, but if the value does not correspond to any existing status check, the status check will be stuck on pending for status since nothing exists to push an actual status
+    requiredStatusChecks:
+    - build
+    # The docs conflict. Are branches required to be up to date before merging. Or Require status checks to pass before merging
+    requiresStrictStatusChecks: false
+    # Restrict who can push to matching branches
+    restrictsPushes: false
+    # Restrict who can dismiss pull request reviews
+    restrictsReviewDismissals: false
+
+  - branchNamePattern: feature/5.0
+    # Specifies whether this branch can be deleted. boolean
+    allowsDeletions: false
+    # Specifies whether forced pushes are allowed on this branch. boolean
+    allowsForcePushes: false
+    # Specifies whether new commits pushed to the matching branches dismiss pull request review approvals. boolean
+    dismissStaleReviews: false
+    # Specifies whether admins can overwrite branch protection. boolean
+    isAdminEnforced: false
+    # Specifies the number of pull request reviews before merging. int (0-6)
+    requiredApprovingReviewsCount: 1
+    # Require review from Code Owners. Requires requiredApprovingReviewsCount. boolean
+    requireCodeOwnersReview: false
+    # Are commits required to be signed. boolean
+    requiresCommitSignatures: false
+    # Are merge commits prohibited from being pushed to this branch. boolean
+    requiresLinearHistory: false
+    # Requires requiresStrictStatusChecks. Values can be any string, but if the value does not correspond to any existing status check, the status check will be stuck on pending for status since nothing exists to push an actual status
+    requiredStatusChecks:
+    - build
+    # The docs conflict. Are branches required to be up to date before merging. Or Require status checks to pass before merging
+    requiresStrictStatusChecks: false
+    # Restrict who can push to matching branches
+    restrictsPushes: false
+    # Restrict who can dismiss pull request reviews
+    restrictsReviewDismissals: false

--- a/.github/policies/msgraph-beta-sdk-dotnet-branch-protection.yml
+++ b/.github/policies/msgraph-beta-sdk-dotnet-branch-protection.yml
@@ -16,7 +16,7 @@ configuration:
     # Specifies whether forced pushes are allowed on this branch. boolean
     allowsForcePushes: false
     # Specifies whether new commits pushed to the matching branches dismiss pull request review approvals. boolean
-    dismissStaleReviews: false
+    dismissStaleReviews: true
     # Specifies whether admins can overwrite branch protection. boolean
     isAdminEnforced: false
     # Specifies the number of pull request reviews before merging. int (0-6)
@@ -31,7 +31,7 @@ configuration:
     requiredStatusChecks:
     - build
     # The docs conflict. Are branches required to be up to date before merging. Or Require status checks to pass before merging
-    requiresStrictStatusChecks: false
+    requiresStrictStatusChecks: true
     # Restrict who can push to matching branches
     restrictsPushes: false
     # Restrict who can dismiss pull request reviews
@@ -43,7 +43,7 @@ configuration:
     # Specifies whether forced pushes are allowed on this branch. boolean
     allowsForcePushes: false
     # Specifies whether new commits pushed to the matching branches dismiss pull request review approvals. boolean
-    dismissStaleReviews: false
+    dismissStaleReviews: true
     # Specifies whether admins can overwrite branch protection. boolean
     isAdminEnforced: false
     # Specifies the number of pull request reviews before merging. int (0-6)
@@ -58,7 +58,7 @@ configuration:
     requiredStatusChecks:
     - build
     # The docs conflict. Are branches required to be up to date before merging. Or Require status checks to pass before merging
-    requiresStrictStatusChecks: false
+    requiresStrictStatusChecks: true
     # Restrict who can push to matching branches
     restrictsPushes: false
     # Restrict who can dismiss pull request reviews

--- a/.github/policies/msgraph-beta-sdk-dotnet-branch-protection.yml
+++ b/.github/policies/msgraph-beta-sdk-dotnet-branch-protection.yml
@@ -37,29 +37,3 @@ configuration:
     # Restrict who can dismiss pull request reviews
     restrictsReviewDismissals: false
 
-  - branchNamePattern: feature/5.0
-    # Specifies whether this branch can be deleted. boolean
-    allowsDeletions: false
-    # Specifies whether forced pushes are allowed on this branch. boolean
-    allowsForcePushes: false
-    # Specifies whether new commits pushed to the matching branches dismiss pull request review approvals. boolean
-    dismissStaleReviews: true
-    # Specifies whether admins can overwrite branch protection. boolean
-    isAdminEnforced: false
-    # Specifies the number of pull request reviews before merging. int (0-6)
-    requiredApprovingReviewsCount: 1
-    # Require review from Code Owners. Requires requiredApprovingReviewsCount. boolean
-    requireCodeOwnersReview: false
-    # Are commits required to be signed. boolean
-    requiresCommitSignatures: false
-    # Are merge commits prohibited from being pushed to this branch. boolean
-    requiresLinearHistory: false
-    # Requires requiresStrictStatusChecks. Values can be any string, but if the value does not correspond to any existing status check, the status check will be stuck on pending for status since nothing exists to push an actual status
-    requiredStatusChecks:
-    - build
-    # The docs conflict. Are branches required to be up to date before merging. Or Require status checks to pass before merging
-    requiresStrictStatusChecks: true
-    # Restrict who can push to matching branches
-    restrictsPushes: false
-    # Restrict who can dismiss pull request reviews
-    restrictsReviewDismissals: false


### PR DESCRIPTION
Initial commit [generated from the existing UI set branch policies using GH CLI](https://github.com/MIchaelMainer/policyservicetoolkit/blob/main/branch_protection_export.ps1). 

Carefully review the policy for additions and changes that should be added here. Review subsequent commits for changes to policy.

> IMPORTANT: Policy changes can be disruptive to workflows.

- [x] add missing policies