### PR TITLE
Update .gitignore to fix failed checkin of generated folder 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,6 @@ Package.StoreAssociation.xml
 
 # VS project upgrade files
 _UpgradeReport_Files/
-Backup*/
 UpgradeLog*.XML
 UpgradeLog*.htm
 .idea/


### PR DESCRIPTION
Fixes failure at https://github.com/microsoftgraph/msgraph-beta-sdk-dotnet/pull/850

CI pipeline fails to checkin the `BackupRestore` request builder due to the gitignore file causing passed build in pipeline but failure in PR. 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/msgraph-beta-sdk-dotnet/pull/851)