### PR TITLE
fix: update to use non obsolete constructors and methods

### DIFF
--- a/src/Microsoft.Graph/GraphServiceClient.cs
+++ b/src/Microsoft.Graph/GraphServiceClient.cs
@@ -13,7 +13,6 @@ namespace Microsoft.Graph.Beta
     using Microsoft.Graph.Core.Requests;
     using Microsoft.Graph.Beta.Requests;
     using Microsoft.Kiota.Abstractions.Authentication;
-    using Microsoft.Kiota.Authentication.Azure;
     using Microsoft.Kiota.Abstractions;
     using Azure.Core;
 
@@ -49,7 +48,7 @@ namespace Microsoft.Graph.Beta
             TokenCredential tokenCredential,
             IEnumerable<string> scopes = null,
             string baseUrl = null
-            ):this(new Microsoft.Graph.Authentication.AzureIdentityAuthenticationProvider(tokenCredential, null, null,scopes?.ToArray() ?? Array.Empty<string>()), baseUrl)
+            ):this(new Microsoft.Graph.Authentication.AzureIdentityAuthenticationProvider(tokenCredential, null, null, true, scopes?.ToArray() ?? []), baseUrl)
         {
         }
 
@@ -65,7 +64,7 @@ namespace Microsoft.Graph.Beta
             TokenCredential tokenCredential,
             IEnumerable<string> scopes = null,
             string baseUrl = null
-        ):this(httpClient, new Microsoft.Graph.Authentication.AzureIdentityAuthenticationProvider(tokenCredential, null, null, scopes?.ToArray() ?? Array.Empty<string>()), baseUrl)
+        ):this(httpClient, new Microsoft.Graph.Authentication.AzureIdentityAuthenticationProvider(tokenCredential, null, null, true, scopes?.ToArray() ?? []), baseUrl)
         {
         }
         

--- a/tests/Microsoft.Graph.DotnetCore.Test/Requests/Functional/OneNoteTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Test/Requests/Functional/OneNoteTests.cs
@@ -3,11 +3,13 @@ namespace Microsoft.Graph.DotnetCore.Test.Requests.Functional
 {
     using Microsoft.Graph.Beta.Models;
     using Microsoft.Kiota.Abstractions;
+    using Microsoft.Kiota.Abstractions.Serialization;
     using Microsoft.Kiota.Serialization.Json;
     using System;
     using System.IO;
     using System.Net.Http;
     using System.Text;
+    using System.Threading;
     using System.Threading.Tasks;
     using Xunit;
     using System.Collections.Generic;
@@ -357,9 +359,7 @@ namespace Microsoft.Graph.DotnetCore.Test.Requests.Functional
                 {
                     // Deserialize into OneNotePage object.
                     var content = await response.Content.ReadAsStreamAsync();
-                    var parseNodeFactory = new JsonParseNodeFactory();
-                    var parseNode = parseNodeFactory.GetRootParseNode(CoreConstants.MimeTypeNames.Application.Json, content);
-                    testPage = parseNode.GetObjectValue<OnenotePage>(OnenotePage.CreateFromDiscriminatorValue);
+                    testPage = await KiotaJsonSerializer.DeserializeAsync<OnenotePage>(content, CancellationToken.None);
 
                     Assert.NotNull(testPage);
                     Assert.Contains(testPage.Title, title);
@@ -413,9 +413,7 @@ namespace Microsoft.Graph.DotnetCore.Test.Requests.Functional
                 // Deserialize into OneNotePage object.
                 // Send the request and get the response.
                 var content = await graphClient.RequestAdapter.SendPrimitiveAsync<Stream>(requestInformation);
-                var parseNodeFactory = new JsonParseNodeFactory();
-                var parseNode = parseNodeFactory.GetRootParseNode(CoreConstants.MimeTypeNames.Application.Json, content);
-                testPage = parseNode.GetObjectValue<OnenotePage>(OnenotePage.CreateFromDiscriminatorValue);
+                testPage = await KiotaJsonSerializer.DeserializeAsync<OnenotePage>(content, CancellationToken.None);
 
                 Assert.NotNull(testPage);
                 Assert.Contains(testPage.Title, title);


### PR DESCRIPTION
Follow up to https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/879

Cleans up obsolete methods in tests.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/msgraph-beta-sdk-dotnet/pull/887)