### PR TITLE
build: fix validate version update script to align to csproj changes

### DIFF
--- a/pipelines/ci-build.yml
+++ b/pipelines/ci-build.yml
@@ -64,6 +64,15 @@ extends:
           inputs:
             command: restore
             projects: '**/*.csproj'
+        - task: PowerShell@2
+          displayName: 'Validate updated version'
+          condition: and(contains(variables['build.sourceBranch'], 'refs/heads/main'), succeeded())
+          inputs:
+            targetType: filePath
+            filePath: '$(Build.SourcesDirectory)\scripts\ValidateUpdatedNugetVersion.ps1'
+            arguments: '-packageName "Microsoft.Graph.Beta" -projectPath "$(Build.SourcesDirectory)\src\Microsoft.Graph\Microsoft.Graph.Beta.csproj"'
+            pwsh: true
+          enabled: true
         - powershell: |
             # This allows us to not have to checkin .csproj files with DelaySign and SignAssembly set to to true. If the flag is set,
             # then project is not debuggable with SignAssembly set to true.
@@ -110,15 +119,6 @@ extends:
           inputs:
             command: 'test'
             arguments: '--configuration $(BuildConfiguration) --no-build --verbosity normal'
-        - task: PowerShell@2
-          displayName: 'Validate updated version'
-          condition: and(contains(variables['build.sourceBranch'], 'refs/heads/main'), succeeded())
-          inputs:
-            targetType: filePath
-            filePath: '$(Build.SourcesDirectory)\scripts\ValidateUpdatedNugetVersion.ps1'
-            arguments: '-packageName "Microsoft.Graph.Beta" -projectPath "$(Build.SourcesDirectory)\src\Microsoft.Graph\Microsoft.Graph.Beta.csproj"'
-            pwsh: true
-          enabled: true
         - task: EsrpCodeSigning@5
           displayName: 'ESRP DLL Strong Name (Microsoft.Graph.Beta)'
           inputs:

--- a/scripts/ValidateUpdatedNugetVersion.ps1
+++ b/scripts/ValidateUpdatedNugetVersion.ps1
@@ -28,15 +28,11 @@ Param(
 
 [xml]$xmlDoc = Get-Content $projectPath
 
-# Assumption: VersionPrefix is set in the first property group.
-$versionPrefixString = $xmlDoc.Project.PropertyGroup[0].VersionPrefix
-if($xmlDoc.Project.PropertyGroup[0].VersionSuffix){
-    $versionPrefixString = $versionPrefixString + "-"  + $xmlDoc.Project.PropertyGroup[0].VersionSuffix
-}
-
+# Assumption: Version is set in the first property group.
+$versionString = $xmlDoc.Project.PropertyGroup[0].Version
 
 # System.Version, get the version prefix.
-$currentProjectVersion = [System.Management.Automation.SemanticVersion]"$versionPrefixString"
+$currentProjectVersion = [System.Management.Automation.SemanticVersion]"$versionString"
 
 # API is case-sensitive
 $packageName = $packageName.ToLower()


### PR DESCRIPTION
Follow up to changes at https://github.com/microsoftgraph/msgraph-beta-sdk-dotnet/pull/860

Fixes the validation script to look for the version in the `Version` tag rather than the `VersionPrefix` tag

Also makes the validation to be happen earlier as if we are going to fail, lets fail early..