### PR TITLE
ci: fixing double tagging and GH releases

### DIFF
--- a/pipelines/ci-build.yml
+++ b/pipelines/ci-build.yml
@@ -304,12 +304,12 @@ extends:
                   inputs:
                     gitHubConnection: 'Kiota_Release'
                     target: $(Build.SourceVersion)
+                    repositoryName: '$(Build.Repository.Name)'
                     action: edit
-                    tagSource: userSpecifiedTag
-                    tag: 'v$(VERSION_STRING)'
-                    title: 'v$(VERSION_STRING)'
+                    tag: $(VERSION_STRING)
+                    addChangeLog: false
+                    assetUploadMode: replace
                     assets: |
                       !**/**
                       $(Pipeline.Workspace)/Microsoft.Graph.Beta.*.*nupkg
-                    addChangeLog: false
 


### PR DESCRIPTION
Fixes double tagging and double releases from CI and release please
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/msgraph-beta-sdk-dotnet/pull/893)