### PR TITLE
ci: remove GitHub release step [skip ci]

### DIFF
--- a/pipelines/ci-build.yml
+++ b/pipelines/ci-build.yml
@@ -298,17 +298,3 @@ extends:
                     packagesToPush: '$(Pipeline.Workspace)\Microsoft.Graph.Beta.*.nupkg'
                     nuGetFeedType: external
                     publishFeedCredentials: 'microsoftgraph NuGet connection'
-                - task: GitHubRelease@1
-                  displayName: 'GitHub release (Upload Artifacts)'
-                  inputs:
-                    gitHubConnection: 'Kiota_Release'
-                    target: $(Build.SourceVersion)
-                    repositoryName: '$(Build.Repository.Name)'
-                    action: edit
-                    tag: $(VERSION_STRING)
-                    addChangeLog: false
-                    assetUploadMode: replace
-                    assets: |
-                      !**/**
-                      $(Pipeline.Workspace)/Microsoft.Graph.Beta.*.*nupkg
-


### PR DESCRIPTION
Removed GitHub release task for uploading artifacts. This is already accomplished using release please
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/msgraph-beta-sdk-dotnet/pull/1064)