### PR TITLE
feat!: update target frameworks to net8.0 and net10.0, drop net5.0

### DIFF
--- a/.github/workflows/validatePullRequest.yml
+++ b/.github/workflows/validatePullRequest.yml
@@ -28,6 +28,8 @@ jobs:
             10.x
       - name: Restore dependencies
         run: dotnet restore ${{ env.solutionName }}
+      # Build each TFM sequentially to avoid OOM kills on the runner.
+      # Building all TFMs in parallel exhausts memory on standard GitHub Actions runners (exit code 137).
       - name: Build for netstandard2.0
         run: dotnet build ${{ env.projectName }} -f netstandard2.0 --no-restore -c Release
       - name: Build for netstandard2.1

--- a/.github/workflows/validatePullRequest.yml
+++ b/.github/workflows/validatePullRequest.yml
@@ -23,15 +23,11 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5.2.0
         with:
-          dotnet-version: 8.x
+          dotnet-version: |
+            8.x
+            10.x
       - name: Restore dependencies
         run: dotnet restore ${{ env.solutionName }}
-      - name: Build for netstandard2.0
-        run: dotnet build ${{ env.projectName }} -f netstandard2.0 --no-restore -c Release
-      - name: Build for netstandard2.1
-        run: dotnet build ${{ env.projectName }} -f netstandard2.1 --no-restore -c Release
-      - name: Build for net5.0
-        run: dotnet build ${{ env.projectName }} -f net5.0 --no-restore -c Release
       - name: Build
         run: dotnet build ${{ env.solutionName }} --no-restore -c Release
       - name: Test
@@ -54,6 +50,12 @@ jobs:
       uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v5.2.0
+      with:
+        dotnet-version: |
+          8.x
+          10.x
     - name: Restore dependencies
       run: dotnet restore ${{ env.solutionName }}
     - name: Build for netstandard2.0

--- a/.github/workflows/validatePullRequest.yml
+++ b/.github/workflows/validatePullRequest.yml
@@ -28,7 +28,15 @@ jobs:
             10.x
       - name: Restore dependencies
         run: dotnet restore ${{ env.solutionName }}
-      - name: Build
+      - name: Build for netstandard2.0
+        run: dotnet build ${{ env.projectName }} -f netstandard2.0 --no-restore -c Release
+      - name: Build for netstandard2.1
+        run: dotnet build ${{ env.projectName }} -f netstandard2.1 --no-restore -c Release
+      - name: Build for net8.0
+        run: dotnet build ${{ env.projectName }} -f net8.0 --no-restore -c Release
+      - name: Build for net10.0
+        run: dotnet build ${{ env.projectName }} -f net10.0 --no-restore -c Release
+      - name: Build test project
         run: dotnet build ${{ env.solutionName }} --no-restore -c Release
       - name: Test
         run: dotnet test ${{ env.solutionName }} --no-build --verbosity normal -c Release /p:CollectCoverage=true /p:CoverletOutput=TestResults/ /p:CoverletOutputFormat=opencover

--- a/pipelines/ci-build.yml
+++ b/pipelines/ci-build.yml
@@ -94,11 +94,28 @@ extends:
             Write-Host "Updated the .csproj files so that we can sign the built assemblies."
           workingDirectory: src
           displayName: 'Set project ready to sign'
+        # Build each TFM sequentially to avoid OOM kills on the build agent.
+        # Building all TFMs in parallel exhausts memory on standard runners (exit code 137).
         - task: DotNetCoreCLI@2
-          displayName: 'dotnet build'
+          displayName: 'dotnet build netstandard2.0'
           inputs:
             projects: '$(Build.SourcesDirectory)\src\Microsoft.Graph\Microsoft.Graph.Beta.csproj'
-            arguments: '-c $(BuildConfiguration) --no-incremental --no-restore'
+            arguments: '-c $(BuildConfiguration) --no-incremental -f netstandard2.0 --no-restore'
+        - task: DotNetCoreCLI@2
+          displayName: 'dotnet build netstandard2.1'
+          inputs:
+            projects: '$(Build.SourcesDirectory)\src\Microsoft.Graph\Microsoft.Graph.Beta.csproj'
+            arguments: '-c $(BuildConfiguration) --no-incremental -f netstandard2.1 --no-restore'
+        - task: DotNetCoreCLI@2
+          displayName: 'dotnet build net8.0'
+          inputs:
+            projects: '$(Build.SourcesDirectory)\src\Microsoft.Graph\Microsoft.Graph.Beta.csproj'
+            arguments: '-c $(BuildConfiguration) --no-incremental -f net8.0 --no-restore'
+        - task: DotNetCoreCLI@2
+          displayName: 'dotnet build net10.0'
+          inputs:
+            projects: '$(Build.SourcesDirectory)\src\Microsoft.Graph\Microsoft.Graph.Beta.csproj'
+            arguments: '-c $(BuildConfiguration) --no-incremental -f net10.0 --no-restore'
         - task: DotNetCoreCLI@2
           displayName: 'dotnet build test project'
           inputs:

--- a/pipelines/ci-build.yml
+++ b/pipelines/ci-build.yml
@@ -52,6 +52,11 @@ extends:
             packageType: sdk
             version: 8.x
         - task: UseDotNet@2
+          displayName: 'Use .NET 10.x sdk'
+          inputs:
+            packageType: sdk
+            version: 10.x
+        - task: UseDotNet@2
           displayName: 'Use .NET 6.x (for code signing tasks)'
           inputs:
             packageType: sdk
@@ -90,22 +95,10 @@ extends:
           workingDirectory: src
           displayName: 'Set project ready to sign'
         - task: DotNetCoreCLI@2
-          displayName: 'dotnet build netstandard2.0'
+          displayName: 'dotnet build'
           inputs:
             projects: '$(Build.SourcesDirectory)\src\Microsoft.Graph\Microsoft.Graph.Beta.csproj'
-            arguments: '-c $(BuildConfiguration) --no-incremental -f netstandard2.0 --no-restore'
-            
-        - task: DotNetCoreCLI@2
-          displayName: 'dotnet build netstandard2.1'
-          inputs:
-            projects: '$(Build.SourcesDirectory)\src\Microsoft.Graph\Microsoft.Graph.Beta.csproj'
-            arguments: '-c $(BuildConfiguration) --no-incremental -f netstandard2.1 --no-restore'
-
-        - task: DotNetCoreCLI@2
-          displayName: 'dotnet build net5.0'
-          inputs:
-            projects: '$(Build.SourcesDirectory)\src\Microsoft.Graph\Microsoft.Graph.Beta.csproj'
-            arguments: '-c $(BuildConfiguration) --no-incremental -f net5.0 --no-restore'
+            arguments: '-c $(BuildConfiguration) --no-incremental --no-restore'
         - task: DotNetCoreCLI@2
           displayName: 'dotnet build test project'
           inputs:

--- a/src/Microsoft.Graph/Microsoft.Graph.Beta.csproj
+++ b/src/Microsoft.Graph/Microsoft.Graph.Beta.csproj
@@ -86,7 +86,8 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <!-- System.Net.Http is required for netstandard2.0 compatibility; suppress NU1510 pruning warning from .NET 10+ SDK -->
+    <PackageReference Include="System.Net.Http" Version="4.3.4" NoWarn="NU1510" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Models\" />

--- a/src/Microsoft.Graph/Microsoft.Graph.Beta.csproj
+++ b/src/Microsoft.Graph/Microsoft.Graph.Beta.csproj
@@ -5,7 +5,7 @@
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <AssemblyTitle>Microsoft Graph Beta Client Library</AssemblyTitle>
     <Authors>Microsoft</Authors>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <PreserveCompilationContext>false</PreserveCompilationContext>
     <AssemblyName>Microsoft.Graph.Beta</AssemblyName>

--- a/tests/Microsoft.Graph.DotnetCore.Test/Microsoft.Graph.DotnetCore.Test.csproj
+++ b/tests/Microsoft.Graph.DotnetCore.Test/Microsoft.Graph.DotnetCore.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <TargetLatestRuntimePatch>false</TargetLatestRuntimePatch>
     <AssemblyName>Microsoft.Graph.DotnetCore.Test</AssemblyName>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>


### PR DESCRIPTION
## Summary
Update the SDK target frameworks from `netstandard2.0;netstandard2.1;net5.0` to `netstandard2.0;netstandard2.1;net8.0;net10.0`.

## Breaking Change
Dropped `net5.0` target framework (EOL). Added `net8.0` and `net10.0`.

## Changes
- Updated TFMs in `Microsoft.Graph.Beta.csproj`
- Updated test project to target `net8.0` and `net10.0`
- Added .NET 10 SDK installation to CI/CD pipelines
- Simplified per-TFM build steps (single build covers all TFMs)

Closes #1110