### PR TITLE
Route NuGet restore through the CFS central package feed

### DIFF
--- a/pipelines/ci-build.yml
+++ b/pipelines/ci-build.yml
@@ -61,11 +61,27 @@ extends:
           inputs:
             packageType: sdk
             version: 6.x
+        - task: NuGetAuthenticate@1
+          displayName: 'Authenticate to Azure Artifacts'
+
+        - pwsh: |
+            @"
+            <?xml version="1.0" encoding="utf-8"?>
+            <configuration>
+              <packageSources>
+                <clear />
+                <add key="GraphDeveloperExperiences_Public" value="https://microsoftgraph.pkgs.visualstudio.com/0985d294-5762-4bc2-a565-161ef349ca3e/_packaging/GraphDeveloperExperiences_Public/nuget/v3/index.json" />
+              </packageSources>
+            </configuration>
+            "@ | Set-Content -Path "$(Build.SourcesDirectory)/nuget.config" -Encoding UTF8
+          displayName: 'Create nuget.config (central feed)'
         - task: DotNetCoreCLI@2
           displayName: 'dotnet restore'
           inputs:
             command: restore
             projects: '**/*.csproj'
+            feedsToUse: "config"
+            nugetConfigPath: "$(Build.SourcesDirectory)/nuget.config"
         - task: PowerShell@2
           displayName: 'Validate updated version'
           condition: and(contains(variables['build.sourceBranch'], 'refs/heads/main'), succeeded())


### PR DESCRIPTION
Routes CI package restore through the authenticated `GraphDeveloperExperiences_Public` Azure Artifacts feed (network isolation / CFS compliance). Adds `NuGetAuthenticate@1` + a generated `nuget.config`. Needs a pipeline run to validate.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/msgraph-beta-sdk-dotnet/pull/1139)